### PR TITLE
fix: clear duplicated agent thoughts logging

### DIFF
--- a/minitap/mobile_use/controllers/mobile_command_controller.py
+++ b/minitap/mobile_use/controllers/mobile_command_controller.py
@@ -9,6 +9,7 @@ from requests import JSONDecodeError
 
 from minitap.mobile_use.clients.device_hardware_client import DeviceHardwareClient
 from minitap.mobile_use.clients.screen_api_client import ScreenApiClient
+from minitap.mobile_use.config import initialize_llm_config
 from minitap.mobile_use.context import DeviceContext, DevicePlatform, MobileUseContext
 from minitap.mobile_use.utils.errors import ControllerErrors
 from minitap.mobile_use.utils.logger import get_logger
@@ -331,12 +332,10 @@ def run_flow_with_wait_for_animation_to_end(
 
 
 if __name__ == "__main__":
-    # long press, erase
-    # input_text(text="test")
-    # erase_text()
     ctx = MobileUseContext(
+        llm_config=initialize_llm_config(),
         device=DeviceContext(
-            host_platform="LINUX",
+            host_platform="WINDOWS",
             mobile_platform=DevicePlatform.ANDROID,
             device_id="emulator-5554",
             device_width=1080,

--- a/minitap/mobile_use/main.py
+++ b/minitap/mobile_use/main.py
@@ -1,9 +1,9 @@
 import asyncio
 import os
-from adbutils import AdbClient
 from typing import Optional
 
 import typer
+from adbutils import AdbClient
 from rich.console import Console
 from typing_extensions import Annotated
 
@@ -41,7 +41,7 @@ async def run_automation(
     agent = Agent(config=config.build())
     agent.init(
         retry_count=int(os.getenv("MOBILE_USE_HEALTH_RETRIES", 5)),
-        retry_wait_seconds=int(os.getenv("MOBILE_USE_HEALTH_DELAY", 5)),
+        retry_wait_seconds=int(os.getenv("MOBILE_USE_HEALTH_DELAY", 2)),
     )
 
     task = agent.new_task(goal)

--- a/minitap/mobile_use/sdk/agent.py
+++ b/minitap/mobile_use/sdk/agent.py
@@ -314,12 +314,12 @@ class Agent:
             self._finalize_tracing(task=task, context=context)
         return output
 
-    def clean(self):
-        if not self._initialized:
+    def clean(self, force: bool = False):
+        if not self._initialized and not force:
             return
         screen_api_ok, hw_bridge_ok = stop_servers(
-            device_screen_api=not self._is_default_screen_api,
-            device_hardware_bridge=not self._is_default_hw_bridge,
+            should_stop_screen_api=self._is_default_screen_api,
+            should_stop_hw_bridge=self._is_default_hw_bridge,
         )
         if not screen_api_ok:
             logger.warning("Failed to stop Device Screen API.")

--- a/minitap/mobile_use/sdk/agent.py
+++ b/minitap/mobile_use/sdk/agent.py
@@ -1,18 +1,32 @@
 import asyncio
-from datetime import datetime
-from pathlib import Path
 import sys
 import tempfile
 import time
+import uuid
+from datetime import datetime
+from pathlib import Path
 from types import NoneType
 from typing import Optional, TypeVar, overload
-import uuid
+
 from adbutils import AdbClient
 from langchain_core.messages import AIMessage
 from pydantic import BaseModel
-from minitap.mobile_use.agents.outputter.outputter import outputter
 
+from minitap.mobile_use.agents.outputter.outputter import outputter
+from minitap.mobile_use.clients.device_hardware_client import DeviceHardwareClient
+from minitap.mobile_use.clients.screen_api_client import ScreenApiClient
 from minitap.mobile_use.config import OutputConfig, record_events
+from minitap.mobile_use.context import (
+    DeviceContext,
+    DevicePlatform,
+    ExecutionSetup,
+    MobileUseContext,
+)
+from minitap.mobile_use.controllers.mobile_command_controller import (
+    ScreenDataResponse,
+    get_screen_data,
+)
+from minitap.mobile_use.controllers.platform_specific_commands_controller import get_first_device
 from minitap.mobile_use.graph.graph import get_graph
 from minitap.mobile_use.graph.state import State
 from minitap.mobile_use.sdk.builders.agent_config_builder import get_default_agent_config
@@ -22,43 +36,28 @@ from minitap.mobile_use.sdk.constants import (
     DEFAULT_SCREEN_API_BASE_URL,
 )
 from minitap.mobile_use.sdk.types.agent import AgentConfig
-from minitap.mobile_use.context import (
-    DeviceContext,
-    DevicePlatform,
-    ExecutionSetup,
-    MobileUseContext,
+from minitap.mobile_use.sdk.types.exceptions import (
+    AgentNotInitializedError,
+    AgentProfileNotFoundError,
+    AgentTaskRequestError,
+    DeviceNotFoundError,
+    ServerStartupError,
 )
-from minitap.mobile_use.clients.device_hardware_client import DeviceHardwareClient
-from minitap.mobile_use.clients.screen_api_client import ScreenApiClient
-from minitap.mobile_use.controllers.mobile_command_controller import (
-    ScreenDataResponse,
-    get_screen_data,
-)
-from minitap.mobile_use.controllers.platform_specific_commands_controller import get_first_device
-
-from minitap.mobile_use.servers.stop_servers import stop_servers
+from minitap.mobile_use.sdk.types.task import AgentProfile, Task, TaskRequest, TaskStatus
 from minitap.mobile_use.servers.device_hardware_bridge import BridgeStatus
 from minitap.mobile_use.servers.start_servers import (
     start_device_hardware_bridge,
     start_device_screen_api,
 )
+from minitap.mobile_use.servers.stop_servers import stop_servers
 from minitap.mobile_use.utils.logger import get_logger
-from minitap.mobile_use.sdk.types.exceptions import (
-    AgentProfileNotFoundError,
-    AgentTaskRequestError,
-    DeviceNotFoundError,
-    ServerStartupError,
-    AgentNotInitializedError,
-)
-from minitap.mobile_use.sdk.types.task import AgentProfile, Task, TaskRequest, TaskStatus
 from minitap.mobile_use.utils.media import (
     create_gif_from_trace_folder,
     create_steps_json_from_trace_folder,
     remove_images_from_trace_folder,
     remove_steps_json_from_trace_folder,
 )
-from minitap.mobile_use.utils.recorder import log_agent_thoughts
-
+from minitap.mobile_use.utils.recorder import log_agent_thought
 
 logger = get_logger(__name__)
 
@@ -262,16 +261,29 @@ class Agent:
                 config={
                     "recursion_limit": task.request.max_steps,
                 },
-                stream_mode=["messages", "custom", "values"],
+                stream_mode=["messages", "custom", "updates", "values"],
             ):
-                stream_mode, content = chunk
+                stream_mode, payload = chunk
                 if stream_mode == "values":
-                    last_state_snapshot = content  # type: ignore
+                    last_state_snapshot = payload  # type: ignore
                     last_state = State(**last_state_snapshot)  # type: ignore
-                    log_agent_thoughts(
-                        agents_thoughts=last_state.agents_thoughts,
-                        output_path=task.request.thoughts_output_path,
-                    )
+                    if task.request.thoughts_output_path:
+                        record_events(
+                            output_path=task.request.thoughts_output_path,
+                            events=last_state.agents_thoughts,
+                        )
+
+                if stream_mode == "updates":
+                    for key, value in payload.items():  # type: ignore
+                        if value and "agents_thoughts" in value:
+                            new_thoughts = value["agents_thoughts"]
+                            last_item = new_thoughts[-1] if new_thoughts else None
+                            if last_item:
+                                log_agent_thought(
+                                    prefix=key,
+                                    agent_thought=last_item,
+                                )
+
             if not last_state:
                 err = f"[{task_name}] No result received from graph"
                 logger.warning(err)

--- a/minitap/mobile_use/servers/stop_servers.py
+++ b/minitap/mobile_use/servers/stop_servers.py
@@ -4,6 +4,7 @@ from typing import List
 
 import psutil
 import requests
+
 from minitap.mobile_use.servers.config import server_settings
 from minitap.mobile_use.servers.device_hardware_bridge import DEVICE_HARDWARE_BRIDGE_PORT
 from minitap.mobile_use.utils.logger import get_server_logger

--- a/minitap/mobile_use/utils/recorder.py
+++ b/minitap/mobile_use/utils/recorder.py
@@ -1,9 +1,9 @@
 import base64
 import time
-from pathlib import Path
 
+from colorama import Fore, Style
 from langchain_core.messages import BaseMessage
-from minitap.mobile_use.config import record_events
+
 from minitap.mobile_use.context import MobileUseContext
 from minitap.mobile_use.controllers.mobile_command_controller import take_screenshot
 from minitap.mobile_use.utils.logger import get_logger
@@ -45,11 +45,12 @@ def record_interaction(ctx: MobileUseContext, response: BaseMessage):
     return "Screenshot recorded successfully"
 
 
-def log_agent_thoughts(agents_thoughts: list[str], output_path: Path | None):
-    if len(agents_thoughts) > 0:
-        last_agents_thoughts = agents_thoughts[-1]
-        previous_last_agents_thoughts = agents_thoughts[-2] if len(agents_thoughts) > 1 else None
-        if previous_last_agents_thoughts != last_agents_thoughts:
-            logger.info(f"💭 {last_agents_thoughts}")
-            if output_path:
-                record_events(output_path=output_path, events=agents_thoughts)
+def log_agent_thought(prefix: str, agent_thought: str):
+    if prefix:
+        prefix = prefix[0].upper() + prefix[1:]
+    else:
+        prefix = "New agent thought"
+    logger.info(
+        f"💭 {Fore.LIGHTMAGENTA_EX + Style.BRIGHT}{prefix}{Style.RESET_ALL}: "
+        f"{Fore.LIGHTMAGENTA_EX}{agent_thought}{Style.RESET_ALL}"
+    )


### PR DESCRIPTION
### 🚀 What's new?

Agents thoughts were printed several times in a row, making the debugging not really convenient.
The thoughts are now only logged on update, not every single time.

An issue with the servers stopping condition has also been fixed

### 🤔 Type of Change

_What kind of change is this? Mark with an `x`_

- [x] **Bug fix** (non-breaking change that solves an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to change)
- [ ] **Documentation** (update to the docs)

### ✅ Checklist

_Before you submit, please make sure you've done the following. If you have any questions, we're here to help!_

- [ ] I have read the **[Contributing Guide](../CONTRIBUTING.md)**.
- [x] My code follows the project's style guidelines (`ruff check .` and `ruff format .` pass).
- [ ] I have added necessary documentation (if applicable).

### 💬 Any questions or comments?

_Have a question or need some help? Join us on **[Discord](https://discord.gg/6nSqmQ9pQs)**!_
