### PR TITLE
feat: Make the Planner and the Cortex aware of the Executor's tools

### DIFF
--- a/minitap/mobile_use/agents/cortex/cortex.md
+++ b/minitap/mobile_use/agents/cortex/cortex.md
@@ -37,9 +37,11 @@ Focus on the **current PENDING subgoal and the next subgoals not yet started**.
 
   2.2. Otherwise, output a **stringified structured set of instructions** that an **Executor agent** can perform on a real mobile device:
 
-- These must be **concrete low-level actions**: back, tap, swipe, launch app, find packages, close app, input text, paste, erase text, copy, etc.
+- These must be **concrete low-level actions**.
+- The executor has the following available tools: **{{ executor_tools_list }}**.
 - Your goal is to achieve subgoals **fast** - so you must put as much actions as possible in your instructions to complete all achievable subgoals (based on your observations) in one go.
-- When you need to open an app, use the `find_packages` low-level action to try and get its name.
+- To open URLs/links directly, use the `open_link` tool - it will automatically handle opening in the appropriate browser. It also handles deep links.
+- When you need to open an app, use the `find_packages` low-level action to try and get its name. Then, simply use the `launch_app` low-level action to launch it.
 - If you refer to a UI element or coordinates, specify it clearly (e.g., `resource-id: com.whatsapp:id/search`, `text: "Alice"`, `x: 100, y: 200`).
 - **The structure is up to you**, but it must be valid **JSON stringified output**. You will accompany this output with a **natural-language summary** of your reasoning and approach in your agent thought.
 - **Never use a sequence of `tap` + `input_text` to type into a field. Always use a single `input_text` action** with the correct `resource_id` (this already ensures the element is focused and the cursor is moved to the end).

--- a/minitap/mobile_use/agents/cortex/cortex.py
+++ b/minitap/mobile_use/agents/cortex/cortex.py
@@ -10,12 +10,14 @@ from langchain_core.messages import (
     ToolMessage,
 )
 from langgraph.graph.message import REMOVE_ALL_MESSAGES
+
 from minitap.mobile_use.agents.cortex.types import CortexOutput
 from minitap.mobile_use.agents.planner.utils import get_current_subgoal
 from minitap.mobile_use.constants import EXECUTOR_MESSAGES_KEY
 from minitap.mobile_use.context import MobileUseContext
 from minitap.mobile_use.graph.state import State
 from minitap.mobile_use.services.llm import get_llm, with_fallback
+from minitap.mobile_use.tools.index import EXECUTOR_WRAPPERS_TOOLS, format_tools_list
 from minitap.mobile_use.utils.conversations import get_screenshot_message_for_llm
 from minitap.mobile_use.utils.decorators import wrap_with_callbacks
 from minitap.mobile_use.utils.logger import get_logger
@@ -44,6 +46,7 @@ class CortexNode:
             current_subgoal=get_current_subgoal(state.subgoal_plan),
             agents_thoughts=state.agents_thoughts,
             executor_feedback=executor_feedback,
+            executor_tools_list=format_tools_list(self.ctx, EXECUTOR_WRAPPERS_TOOLS),
         )
         messages = [
             SystemMessage(content=system_message),

--- a/minitap/mobile_use/agents/cortex/cortex.py
+++ b/minitap/mobile_use/agents/cortex/cortex.py
@@ -86,7 +86,7 @@ class CortexNode:
         is_subgoal_completed = (
             response.complete_subgoals_by_ids is not None
             and len(response.complete_subgoals_by_ids) > 0
-            and len(response.decisions) == 0
+            and (len(response.decisions) == 0 or response.decisions in ["{}", "[]", "null", ""])
         )
         if not is_subgoal_completed:
             response.complete_subgoals_by_ids = []

--- a/minitap/mobile_use/agents/planner/planner.md
+++ b/minitap/mobile_use/agents/planner/planner.md
@@ -12,7 +12,9 @@ You work like an agile tech lead: defining the key milestones without locking in
    - Subgoals should reflect real interactions with mobile UIs (e.g. "Open app", "Tap search bar", "Scroll to item", "Send message to Bob", etc).
    - Don't assume the full UI is visible yet. Plan based on how most mobile apps work, and keep flexibility.
    - List of agents thoughts is empty which is expected, since it is the first plan.
-   - Don't use precise UI actions when formulating subgoals like "copy", "paste", "tap", "swipe", ... unless explicitly asked in the initial goal.
+   - Avoid too granular UI actions based tasks (e.g. "tap", "swipe", "copy", "paste") unless explicitly required.
+   - The executor has the following available tools: **{{ executor_tools_list }}**.
+     When one of these tools offers a direct shortcut (e.g. `openLink` instead of manually launching a browser and typing a URL), prefer it over decomposed manual steps.
 
 2. **Replanning**
    If you're asked to **revise a previous plan**, you'll also receive:
@@ -47,12 +49,19 @@ If you're replaning and need to keep a previous subgoal, you **must keep the sam
 - Type the message "I’m running late" (ID: None)
 - Send the message (ID: None)
 
+#### **Initial Goal**: "Go on https://tesla.com, and tell me what is the first car being displayed"
+
+**Plan**:
+
+- Open the link https://tesla.com (ID: None)
+- Find the first car displayed on the home page (ID: None)
+
 #### **Replanning Example**
 
 **Original Plan**: same as above with IDs set
 **Agent Thoughts**:
 
-- Couldn’t find Alice in recent chats
+- Couldn't find Alice in recent chats
 - Search bar was present on top of the chat screen
 - Keyboard appeared after tapping search
 

--- a/minitap/mobile_use/agents/planner/planner.py
+++ b/minitap/mobile_use/agents/planner/planner.py
@@ -1,13 +1,15 @@
-from pathlib import Path
 import uuid
+from pathlib import Path
 
 from jinja2 import Template
 from langchain_core.messages import HumanMessage, SystemMessage
+
 from minitap.mobile_use.agents.planner.types import PlannerOutput, Subgoal, SubgoalStatus
 from minitap.mobile_use.agents.planner.utils import one_of_them_is_failure
 from minitap.mobile_use.context import MobileUseContext
 from minitap.mobile_use.graph.state import State
 from minitap.mobile_use.services.llm import get_llm
+from minitap.mobile_use.tools.index import EXECUTOR_WRAPPERS_TOOLS, format_tools_list
 from minitap.mobile_use.utils.decorators import wrap_with_callbacks
 from minitap.mobile_use.utils.logger import get_logger
 
@@ -36,6 +38,7 @@ class PlannerNode:
             initial_goal=state.initial_goal,
             previous_plan="\n".join(str(s) for s in state.subgoal_plan),
             agent_thoughts="\n".join(state.agents_thoughts),
+            executor_tools_list=format_tools_list(self.ctx, EXECUTOR_WRAPPERS_TOOLS),
         )
         messages = [
             SystemMessage(content=system_message),

--- a/minitap/mobile_use/tools/index.py
+++ b/minitap/mobile_use/tools/index.py
@@ -46,6 +46,10 @@ def get_tools_from_wrappers(ctx: MobileUseContext, wrappers: list[ToolWrapper]) 
     return [wrapper.tool_fn_getter(ctx) for wrapper in wrappers]
 
 
+def format_tools_list(ctx: MobileUseContext, wrappers: list[ToolWrapper]) -> str:
+    return "\n".join([tool.name for tool in get_tools_from_wrappers(ctx, wrappers)])
+
+
 def get_tool_wrapper_from_name(name: str) -> ToolWrapper | None:
     """Get the tool wrapper from the name."""
     for wrapper in EXECUTOR_WRAPPERS_TOOLS:


### PR DESCRIPTION
### 🚀 What's new?

- Introduce a utility to format tool names from any tool wrappers list
- Inject this list into the cortex and planner system prompts so they are aware of the executor tools
- Fix a bug where empty Cortex decisions ({}, [], instead of an empty string) were not detected by the orchestrator, causing unnecessary loops

### 🤔 Type of Change

_What kind of change is this? Mark with an `x`_

- [ ] **Bug fix** (non-breaking change that solves an issue)
- [x] **New feature** (non-breaking change that adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to change)
- [ ] **Documentation** (update to the docs)

### ✅ Checklist

_Before you submit, please make sure you've done the following. If you have any questions, we're here to help!_

- [ ] I have read the **[Contributing Guide](../CONTRIBUTING.md)**.
- [x] My code follows the project's style guidelines (`ruff check .` and `ruff format .` pass).
- [ ] I have added necessary documentation (if applicable).

### 💬 Any questions or comments?

_Have a question or need some help? Join us on **[Discord](https://discord.gg/6nSqmQ9pQs)**!_
