### PR TITLE
fix: inspect executor messages for sceenshot tool calls instead of base messages key

### DIFF
--- a/minitap/mobile_use/agents/contextor/contextor.py
+++ b/minitap/mobile_use/agents/contextor/contextor.py
@@ -1,4 +1,5 @@
 from minitap.mobile_use.agents.executor.utils import is_last_tool_message_take_screenshot
+from minitap.mobile_use.context import MobileUseContext
 from minitap.mobile_use.controllers.mobile_command_controller import get_screen_data
 from minitap.mobile_use.controllers.platform_specific_commands_controller import (
     get_device_date,
@@ -7,7 +8,6 @@ from minitap.mobile_use.controllers.platform_specific_commands_controller import
 from minitap.mobile_use.graph.state import State
 from minitap.mobile_use.utils.decorators import wrap_with_callbacks
 from minitap.mobile_use.utils.logger import get_logger
-from minitap.mobile_use.context import MobileUseContext
 
 logger = get_logger(__name__)
 
@@ -26,7 +26,9 @@ class ContextorNode:
         focused_app_info = get_focused_app_info(self.ctx)
         device_date = get_device_date(self.ctx)
 
-        should_add_screenshot_context = is_last_tool_message_take_screenshot(list(state.messages))
+        should_add_screenshot_context = is_last_tool_message_take_screenshot(
+            list(state.executor_messages)
+        )
 
         return state.sanitize_update(
             ctx=self.ctx,


### PR DESCRIPTION
### 🚀 What's new?

When we migrated from messages to `executor_messages` state's key logic, we actually forgot to update how we searched for screenshot tools while clearing the context before giving it to the cortex. 

- Fixed that by replacing `state.messages` with `state.executor_messages`

### 🤔 Type of Change

_What kind of change is this? Mark with an `x`_

- [x] **Bug fix** (non-breaking change that solves an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to change)
- [ ] **Documentation** (update to the docs)

### ✅ Checklist

_Before you submit, please make sure you've done the following. If you have any questions, we're here to help!_

- [x] I have read the **[Contributing Guide](../CONTRIBUTING.md)**.
- [x] My code follows the project's style guidelines (`ruff check .` and `ruff format .` pass).
- [ ] I have added necessary documentation (if applicable).

### 💬 Any questions or comments?

_Have a question or need some help? Join us on **[Discord](https://discord.gg/6nSqmQ9pQs)**!_
