### PR TITLE
fix(sdk): retry upon startup when Maestro server is in failed state

### DIFF
--- a/minitap/mobile_use/sdk/agent.py
+++ b/minitap/mobile_use/sdk/agent.py
@@ -496,7 +496,10 @@ class Agent:
 
     def _check_device_screen_api_health(self) -> bool:
         try:
+            # Required to know if the Screen API is up
             self._screen_api_client.get_with_retry("/health", timeout=5)
+            # Required to know if the Screen API actually receives screenshot from the HW Bridge API
+            self._screen_api_client.get_with_retry("/screen-info", timeout=5)
             return True
         except Exception as e:
             logger.error(f"Device Screen API health check failed: {e}")


### PR DESCRIPTION
### 🚀 What's new?

If Maestro was already started and in a failed state (e.g. device disconnected), it would crash later when fetching the screen information from Screen API.
Therefore, in addition to checking the `/health` endpoint, I also added a check for the `/screen-info` endpoint.

Ref: #51 

### 🤔 Type of Change

_What kind of change is this? Mark with an `x`_

- [x] **Bug fix** (non-breaking change that solves an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to change)
- [ ] **Documentation** (update to the docs)

### ✅ Checklist

_Before you submit, please make sure you've done the following. If you have any questions, we're here to help!_

- [x] I have read the **[Contributing Guide](../CONTRIBUTING.md)**.
- [x] My code follows the project's style guidelines (`ruff check .` and `ruff format .` pass).
- [ ] I have added necessary documentation (if applicable).

### 💬 Any questions or comments?

_Have a question or need some help? Join us on **[Discord](https://discord.gg/6nSqmQ9pQs)**!_
