### PR TITLE
Fix iOS device detection by checking for Darwin instead of Linux

### DIFF
--- a/minitap/mobile_use/clients/ios_client.py
+++ b/minitap/mobile_use/clients/ios_client.py
@@ -14,7 +14,7 @@ def get_ios_devices() -> tuple[bool, list[str], str]:
         - list[str]: A list of iOS device UDIDs.
         - str: An error message if any.
     """
-    if platform.system() != "Linux":
+    if platform.system() != "Darwin":
         return False, [], "xcrun is only available on macOS."
 
     try:


### PR DESCRIPTION
fix: update platform check in iOS client to macOS

### 🚀 What's new?

This PR fixes a critical bug in the iOS device detection logic. The platform check was incorrectly comparing against `"Linux"` instead of `"Darwin"`, which prevented the iOS simulator device enumeration from working on macOS.

**Problem**: The `get_ios_devices()` function would always return early with an error on macOS because `platform.system()` returns `"Darwin"` on macOS, not `"Linux"`. This made it impossible to detect and list iOS simulator devices.

**Solution**: Changed the platform check from `platform.system() != "Linux"` to `platform.system() != "Darwin"` to correctly validate that the code is running on macOS before attempting to use the `xcrun simctl` command.

### 🤔 Type of Change

_What kind of change is this? Mark with an `x`_

- [x] **Bug fix** (non-breaking change that solves an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to change)
- [ ] **Documentation** (update to the docs)

### ✅ Checklist

_Before you submit, please make sure you've done the following. If you have any questions, we're here to help!_

- [x] I have read the **[Contributing Guide](../CONTRIBUTING.md)**.
- [x] My code follows the project's style guidelines (`ruff check .` and `ruff format .` pass).
- [x] I have added necessary documentation (if applicable).

### 💬 Any questions or comments?

_Have a question or need some help? Join us on **[Discord](https://discord.gg/6nSqmQ9pQs)**!_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected platform detection for iOS device discovery to run only on macOS, preventing failures on unsupported systems.
  * On non-macOS platforms, the feature now exits early with a clear message indicating that xcrun is only available on macOS.
  * This provides more predictable behavior and clearer guidance for users. No changes are required for macOS users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->