### PR TITLE
fix: ignore known benign warnings in device hardware bridge logs

### DIFF
--- a/minitap/mobile_use/servers/device_hardware_bridge.py
+++ b/minitap/mobile_use/servers/device_hardware_bridge.py
@@ -135,14 +135,25 @@ class DeviceHardwareBridge:
             print(f"[Maestro Studio ERROR]: {line}")
             self.output.append(line)
 
-            if "device offline" in line.lower():
+            lower_line = line.lower()
+
+            # Ignore known benign warnings (common on macOS/JDK 21+)
+            if line.startswith("WARNING:") or (
+                "restricted method" in lower_line
+                or "jansi" in lower_line
+                or "enable-native-access" in lower_line
+                or "java.lang.system::load" in lower_line
+            ):
+                continue
+
+            if "device offline" in lower_line:
                 with self.lock:
                     self.status = BridgeStatus.FAILED
                 if self.process:
                     self.process.kill()
                 break
 
-            if "address already in use" in line.lower():
+            if "address already in use" in lower_line:
                 with self.lock:
                     self.status = BridgeStatus.PORT_IN_USE
                 if self.process:


### PR DESCRIPTION
### 🚀 What's new?

Fixing a bug where maestro studio could not start for MacOS users running with SDK 21+

### 🤔 Type of Change

_What kind of change is this? Mark with an `x`_

- [x] **Bug fix** (non-breaking change that solves an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to change)
- [ ] **Documentation** (update to the docs)

### ✅ Checklist

_Before you submit, please make sure you've done the following. If you have any questions, we're here to help!_

- [ ] I have read the **[Contributing Guide](../CONTRIBUTING.md)**.
- [ ] My code follows the project's style guidelines (`ruff check .` and `ruff format .` pass).
- [ ] I have added necessary documentation (if applicable).

### 💬 Any questions or comments?

_Have a question or need some help? Join us on **[Discord](https://discord.gg/6nSqmQ9pQs)**!_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Suppressed benign warnings from logs to reduce noise.
  * Improved detection of device offline events and ensured proper process termination.
  * Enhanced recognition of port-in-use errors for clearer failure reporting.
  * More reliable transition from starting to failed state when startup cannot proceed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->