### PR TITLE
feat: add timestamp validation for screen data freshness

### DIFF
--- a/minitap/mobile_use/servers/device_screen_api.py
+++ b/minitap/mobile_use/servers/device_screen_api.py
@@ -1,3 +1,4 @@
+import asyncio
 import base64
 import json
 import threading
@@ -131,7 +132,7 @@ async def get_screen_info():
     waited_for_seconds = 0
     while not _latest_screen_ts or _latest_screen_ts < now:
         wait_for_seconds = 0.05
-        time.sleep(wait_for_seconds)
+        await asyncio.sleep(wait_for_seconds)
         waited_for_seconds += wait_for_seconds
         if waited_for_seconds >= MAX_WAIT_TIME:
             break


### PR DESCRIPTION
### 🚀 What's new?

Contextor sometimes retrieved an old UI hierarchy (a11y tree)
This fix ensures it always fetches a fresh new hierarchy.

### 🤔 Type of Change

_What kind of change is this? Mark with an `x`_

- [ ] **Bug fix** (non-breaking change that solves an issue)
- [x] **New feature** (non-breaking change that adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to change)
- [ ] **Documentation** (update to the docs)

### ✅ Checklist

_Before you submit, please make sure you've done the following. If you have any questions, we're here to help!_

- [ ] I have read the **[Contributing Guide](../CONTRIBUTING.md)**.
- [ ] My code follows the project's style guidelines (`ruff check .` and `ruff format .` pass).
- [ ] I have added necessary documentation (if applicable).

### 💬 Any questions or comments?

_Have a question or need some help? Join us on **[Discord](https://discord.gg/6nSqmQ9pQs)**!_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device screen data reliability by introducing timestamp-based readiness gating and a short startup wait so requests receive valid screen information. Streaming now updates the latest-screen marker to coordinate readiness. Existing streaming and health endpoints remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->