### PR TITLE
feat: add execution_origin parameter throughout task execution flow

### DIFF
--- a/minitap/mobile_use/sdk/agent.py
+++ b/minitap/mobile_use/sdk/agent.py
@@ -305,7 +305,9 @@ class Agent:
                     "Use AgentConfigBuilder.for_cloud_mobile() only with PlatformTaskRequest."
                 )
             # Use cloud mobile execution path
-            return await self._run_cloud_mobile_task(request=request)
+            return await self._run_cloud_mobile_task(
+                request=request, locked_app_package=locked_app_package
+            )
 
         # Normal local execution path
         if request is not None:
@@ -350,6 +352,7 @@ class Agent:
     async def _run_cloud_mobile_task(
         self,
         request: PlatformTaskRequest[TOutput],
+        locked_app_package: str | None = None,
     ) -> str | dict | TOutput | None:
         """
         Execute a task on a cloud mobile.
@@ -391,6 +394,7 @@ class Agent:
                     request=request,
                     on_status_update=status_callback,
                     on_log=log_callback,
+                    locked_app_package=locked_app_package,
                 )
                 if final_status == "completed":
                     logger.success("Cloud mobile task completed successfully")

--- a/minitap/mobile_use/sdk/services/platform.py
+++ b/minitap/mobile_use/sdk/services/platform.py
@@ -102,6 +102,7 @@ class PlatformService:
                     profile=profile,
                     virtual_mobile_id=virtual_mobile_id,
                     locked_app_package=locked_app_package,
+                    execution_origin=request.execution_origin,
                 )
             else:
                 # Create task manually from ManualTaskConfig
@@ -132,6 +133,7 @@ class PlatformService:
                     profile=profile,
                     virtual_mobile_id=virtual_mobile_id,
                     locked_app_package=locked_app_package,
+                    execution_origin=request.execution_origin,
                 )
 
             return PlatformTaskInfo(
@@ -265,6 +267,7 @@ class PlatformService:
         profile: LLMProfileResponse,
         virtual_mobile_id: str | None = None,
         locked_app_package: str | None = None,
+        execution_origin: str | None = None,
     ) -> TaskRunResponse:
         try:
             logger.info(f"Creating task run for task: {task.name}")
@@ -273,6 +276,7 @@ class PlatformService:
                 llm_profile_id=profile.id,
                 virtual_mobile_id=virtual_mobile_id,
                 locked_app_package=locked_app_package,
+                execution_origin=execution_origin,
             )
             response = await self._client.post(url="v1/task-runs", json=task_run.model_dump())
             response.raise_for_status()
@@ -289,6 +293,7 @@ class PlatformService:
         profile: LLMProfileResponse,
         virtual_mobile_id: str | None = None,
         locked_app_package: str | None = None,
+        execution_origin: str | None = None,
     ) -> TaskRunResponse:
         """
         Create an orphan task run from a manual task configuration.
@@ -304,6 +309,7 @@ class PlatformService:
                 "llmProfileId": profile.id,
                 "virtualMobileId": virtual_mobile_id,
                 "lockedAppPackage": locked_app_package,
+                "executionOrigin": execution_origin,
             }
 
             response = await self._client.post(url="v1/task-runs/orphan", json=orphan_payload)

--- a/minitap/mobile_use/sdk/types/platform.py
+++ b/minitap/mobile_use/sdk/types/platform.py
@@ -65,6 +65,7 @@ class CreateTaskRunRequest(BaseApiModel):
     llm_profile_id: str = Field(..., description="LLM profile ID to use")
     virtual_mobile_id: str | None = Field(None, description="Virtual mobile ID to use")
     locked_app_package: str | None = Field(None, description="App package to lock for the task run")
+    execution_origin: str | None = Field(None, description="Origin of the task execution")
 
 
 class UpdateTaskRunStatusRequest(BaseApiModel):

--- a/minitap/mobile_use/sdk/types/task.py
+++ b/minitap/mobile_use/sdk/types/task.py
@@ -130,10 +130,12 @@ class PlatformTaskRequest[TOutput](TaskRequestBase):
         task: Either a task name to fetch from the platform, or a
               ManualTaskConfig to create manually
         profile: Optional profile name specified by the user on the platform
+        execution_origin: Origin of the task execution (default: "sdk")
     """
 
     task: str | ManualTaskConfig
     profile: str | None = None
+    execution_origin: str = "sdk"
 
 
 class CloudDevicePlatformTaskRequest[TOutput](PlatformTaskRequest[TOutput]):


### PR DESCRIPTION
Forward execution_origin from PlatformTaskRequest through the entire task execution pipeline, including cloud mobile service, platform service, and task run creation. Default value is "sdk" for SDK-originated tasks.

### 🚀 What's new?

_Describe the purpose of your pull request. What problem does it solve? What feature does it add? Link to any relevant issues!_

### 🤔 Type of Change

_What kind of change is this? Mark with an `x`_

- [ ] **Bug fix** (non-breaking change that solves an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to change)
- [ ] **Documentation** (update to the docs)

### ✅ Checklist

_Before you submit, please make sure you've done the following. If you have any questions, we're here to help!_

- [ ] I have read the **[Contributing Guide](../CONTRIBUTING.md)**.
- [ ] My code follows the project's style guidelines (`ruff check .` and `ruff format .` pass).
- [ ] I have added necessary documentation (if applicable).

### 💬 Any questions or comments?

_Have a question or need some help? Join us on **[Discord](https://discord.gg/6nSqmQ9pQs)**!_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for locking a specific app package during cloud mobile task execution.
  * Added execution origin tracking to identify where tasks are initiated from during execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->