### PR TITLE
feat: better documentation of the element bounds for tool input

### DIFF
--- a/minitap/mobile_use/agents/cortex/cortex.md
+++ b/minitap/mobile_use/agents/cortex/cortex.md
@@ -46,7 +46,7 @@ When targeting ANY element (tap, input, clear...), provide ALL available info:
   "target": {
     "resource_id": "com.app:id/button",
     "resource_id_index": 0,
-    "coordinates": {"x": 100, "y": 200, "width": 50, "height": 50},
+    "bounds": {"x": 100, "y": 200, "width": 50, "height": 50},
     "text": "Submit",
     "text_index": 0
   }
@@ -55,9 +55,9 @@ When targeting ANY element (tap, input, clear...), provide ALL available info:
 
 - `resource_id_index` = index among elements with same resource_id
 - `text_index` = index among elements with same text
-- This enables **fallback**: if ID fails → tries coordinates → tries text
+- This enables **fallback**: if ID fails → tries bounds → tries text
 
-**On tap failure:** "Out of bounds" = stale coordinates. "No element found" = screen changed. Adapt, don't retry blindly.
+**On tap failure:** "Out of bounds" = stale bounds. "No element found" = screen changed. Adapt, don't retry blindly.
 
 ---
 
@@ -110,7 +110,7 @@ Session locked to: **{{ locked_app_package }}**
 **Output:**
 ```
 complete_subgoals_by_ids: ["subgoal-4-type-message"]
-Structured Decisions: "[{\"action\": \"tap\", \"target\": {\"resource_id\": \"com.whatsapp:id/send\", \"resource_id_index\": 0, \"coordinates\": {\"x\": 950, \"y\": 1800, \"width\": 100, \"height\": 100}}}]"
+Structured Decisions: "[{\"action\": \"tap\", \"target\": {\"resource_id\": \"com.whatsapp:id/send\", \"resource_id_index\": 0, \"bounds\": {\"x\": 950, \"y\": 1800, \"width\": 100, \"height\": 100}}}]"
 Decisions Reason: Agent thoughts confirm typing succeeded. Completing typing subgoal based on observed evidence. Now tapping send with full target info.
 Goals Completion Reason: Executor feedback confirmed "Hello!" was entered successfully.
 ```

--- a/minitap/mobile_use/agents/executor/executor.md
+++ b/minitap/mobile_use/agents/executor/executor.md
@@ -16,7 +16,7 @@ Interpret Cortex decisions and execute tools on {{ platform }} mobile device. Yo
 
 **Cortex decision:**
 ```json
-"[{\"action\": \"tap\", \"target\": {\"resource_id\": \"com.whatsapp:id/chat\", \"text\": \"Alice\", \"coordinates\": {\"x\": 100, \"y\": 350}}}]"
+"[{\"action\": \"tap\", \"target\": {\"resource_id\": \"com.whatsapp:id/chat\", \"text\": \"Alice\", \"bounds\": {\"x\": 100, \"y\": 350, \"width\": 50, \"height\": 50}}}]"
 ```
 
 **You execute:**

--- a/minitap/mobile_use/tools/mobile/long_press_on.py
+++ b/minitap/mobile_use/tools/mobile/long_press_on.py
@@ -30,11 +30,11 @@ def get_long_press_on_tool(ctx: MobileUseContext) -> BaseTool:
         Long presses on a UI element identified by the 'target' object.
 
         The 'target' object allows specifying an element by its resource_id
-        (with an optional index), its coordinates, or its text content (with an optional index).
+        (with an optional index), its bounds, or its text content (with an optional index).
         The tool uses a fallback strategy, trying the locators in that order.
 
         Args:
-            target: The UI element to long press on (coordinates, resource_id, or text).
+            target: The UI element to long press on (bounds, resource_id, or text).
             duration_ms: Duration of the long press in milliseconds. Choose based on interaction:
                         - 500-800ms: Quick long press (e.g., selecting text, haptic feedback)
                         - 1000ms (default): Standard long press (most common use case)
@@ -49,13 +49,13 @@ def get_long_press_on_tool(ctx: MobileUseContext) -> BaseTool:
         controller = UnifiedMobileController(ctx)
 
         # 1. Try with COORDINATES FIRST (visual approach)
-        if target.coordinates:
+        if target.bounds:
             try:
-                center_point = target.coordinates.get_center()
+                center_point = target.bounds.get_center()
                 logger.info(
                     f"Attempting to long press using coordinates: {center_point.x},{center_point.y}"
                 )
-                latest_selector_info = f"coordinates='{target.coordinates}'"
+                latest_selector_info = f"coordinates='{target.bounds}'"
                 result = await controller.tap_at(
                     x=center_point.x,
                     y=center_point.y,
@@ -66,13 +66,13 @@ def get_long_press_on_tool(ctx: MobileUseContext) -> BaseTool:
                     error_obj = None
                 else:
                     logger.warning(
-                        f"Long press with coordinates '{target.coordinates}' failed. "
+                        f"Long press with coordinates '{target.bounds}' failed. "
                         f"Error: {result.error}"
                     )
                     error_obj = {"error": result.error}
             except Exception as e:
                 logger.warning(
-                    f"Exception during long press with coordinates '{target.coordinates}': {e}"
+                    f"Exception during long press with coordinates '{target.bounds}': {e}"
                 )
                 error_obj = {"error": str(e)}
 

--- a/minitap/mobile_use/tools/mobile/tap.py
+++ b/minitap/mobile_use/tools/mobile/tap.py
@@ -30,7 +30,7 @@ def get_tap_tool(ctx: MobileUseContext) -> BaseTool:
         Taps on a UI element identified by the 'target' object.
 
         The 'target' object allows specifying an element by its resource_id
-        (with an optional index), its coordinates, or its text content (with an optional index).
+        (with an optional index), its bounds, or its text content (with an optional index).
         The tool uses a fallback strategy, trying the locators in that order.
         """
         # Track all attempts for better error reporting
@@ -43,15 +43,15 @@ def get_tap_tool(ctx: MobileUseContext) -> BaseTool:
             attempts.append(
                 {
                     "selector": "none",
-                    "error": "No valid selector provided (need coordinates, resource_id, or text)",
+                    "error": "No valid selector provided (need bounds, resource_id, or text)",
                 }
             )
 
         controller = UnifiedMobileController(ctx)
 
         # 1. Try with COORDINATES FIRST (visual approach)
-        if not success and target.coordinates:
-            center = target.coordinates.get_center()
+        if not success and target.bounds:
+            center = target.bounds.get_center()
             selector_info = f"coordinates ({center.x}, {center.y})"
 
             # Validate bounds before attempting
@@ -65,7 +65,7 @@ def get_tap_tool(ctx: MobileUseContext) -> BaseTool:
                 )
             else:
                 try:
-                    center_point = target.coordinates.get_center()
+                    center_point = target.bounds.get_center()
                     logger.info(f"Attempting tap with {selector_info}")
                     result = await controller.tap_at(x=center_point.x, y=center_point.y)
                     if result.error is None:

--- a/minitap/mobile_use/tools/test_utils.py
+++ b/minitap/mobile_use/tools/test_utils.py
@@ -98,7 +98,7 @@ class TestMoveCursorToEndIfBounds:
             resource_id_index=None,
             text=None,
             text_index=None,
-            coordinates=None,
+            bounds=None,
         )
         result = asyncio.run(
             move_cursor_to_end_if_bounds(ctx=mock_context, state=mock_state, target=target)
@@ -130,7 +130,7 @@ class TestMoveCursorToEndIfBounds:
             resource_id_index=None,
             text=None,
             text_index=None,
-            coordinates=bounds,
+            bounds=bounds,
         )
 
         result = asyncio.run(
@@ -160,7 +160,7 @@ class TestMoveCursorToEndIfBounds:
             resource_id_index=None,
             text="Sample text",
             text_index=0,
-            coordinates=None,
+            bounds=None,
         )
         result = asyncio.run(
             move_cursor_to_end_if_bounds(ctx=mock_context, state=mock_state, target=target)
@@ -184,7 +184,7 @@ class TestMoveCursorToEndIfBounds:
             resource_id_index=None,
             text="Nonexistent text",
             text_index=None,
-            coordinates=None,
+            bounds=None,
         )
         result = asyncio.run(
             move_cursor_to_end_if_bounds(ctx=mock_context, state=mock_state, target=target)
@@ -208,7 +208,7 @@ class TestMoveCursorToEndIfBounds:
             resource_id_index=None,
             text="Text without bounds",
             text_index=None,
-            coordinates=None,
+            bounds=None,
         )
         result = asyncio.run(
             move_cursor_to_end_if_bounds(ctx=mock_context, state=mock_state, target=target)
@@ -227,7 +227,7 @@ class TestMoveCursorToEndIfBounds:
             resource_id_index=None,
             text=None,
             text_index=None,
-            coordinates=None,
+            bounds=None,
         )
         result = asyncio.run(
             move_cursor_to_end_if_bounds(ctx=mock_context, state=mock_state, target=target)
@@ -258,7 +258,7 @@ class TestFocusElementIfNeeded:
             resource_id_index=None,
             text=None,
             text_index=None,
-            coordinates=None,
+            bounds=None,
         )
         result = asyncio.run(focus_element_if_needed(ctx=mock_context, target=target))
 
@@ -291,7 +291,7 @@ class TestFocusElementIfNeeded:
             resource_id_index=None,
             text=None,
             text_index=None,
-            coordinates=None,
+            bounds=None,
         )
         result = asyncio.run(focus_element_if_needed(ctx=mock_context, target=target))
 
@@ -334,7 +334,7 @@ class TestFocusElementIfNeeded:
                 resource_id_index=None,
                 text="Sample text",
                 text_index=None,
-                coordinates=None,
+                bounds=None,
             )
             result = asyncio.run(focus_element_if_needed(ctx=mock_context, target=target))
 
@@ -366,7 +366,7 @@ class TestFocusElementIfNeeded:
             resource_id_index=None,
             text="Sample text",
             text_index=None,
-            coordinates=None,
+            bounds=None,
         )
         result = asyncio.run(focus_element_if_needed(ctx=mock_context, target=target))
 
@@ -398,7 +398,7 @@ class TestFocusElementIfNeeded:
                 resource_id_index=None,
                 text="nonexistent",
                 text_index=None,
-                coordinates=None,
+                bounds=None,
             )
             result = asyncio.run(focus_element_if_needed(ctx=mock_context, target=target))
 

--- a/minitap/mobile_use/tools/types.py
+++ b/minitap/mobile_use/tools/types.py
@@ -19,7 +19,7 @@ class Target(BaseModel):
     text_index: int | None = Field(
         None, description="The zero-based index if multiple elements share the same text."
     )
-    coordinates: ElementBounds | None = Field(
+    bounds: ElementBounds | None = Field(
         None, description="The x, y, width, and height of the element."
     )
 

--- a/minitap/mobile_use/tools/utils.py
+++ b/minitap/mobile_use/tools/utils.py
@@ -106,8 +106,8 @@ async def move_cursor_to_end_if_bounds(
         logger.debug(f"Tapped end of input {target.resource_id}")
         return elt
 
-    if target.coordinates:
-        await tap_bottom_right_of_element(target.coordinates, ctx=ctx)
+    if target.bounds:
+        await tap_bottom_right_of_element(target.bounds, ctx=ctx)
         logger.debug("Tapped end of input by coordinates")
         return elt
 
@@ -172,8 +172,8 @@ async def focus_element_if_needed(
             return "resource_id"
         logger.warning(f"Failed to focus using resource_id='{target.resource_id}'. Fallback...")
 
-    if target.coordinates:
-        relative_point = target.coordinates.get_center()
+    if target.bounds:
+        relative_point = target.bounds.get_center()
         await tap(
             ctx=ctx,
             selector_request=SelectorRequestWithCoordinates(
@@ -213,10 +213,10 @@ def validate_coordinates_bounds(
     Validate that coordinates are within screen bounds.
     Returns error message if invalid, None if valid.
     """
-    if not target.coordinates:
+    if not target.bounds:
         return None
 
-    center = target.coordinates.get_center()
+    center = target.bounds.get_center()
     errors = []
 
     if center.x < 0 or center.x >= screen_width:
@@ -229,7 +229,7 @@ def validate_coordinates_bounds(
 
 def has_valid_selectors(target: Target) -> bool:
     """Check if target has at least one valid selector."""
-    has_coordinates = target.coordinates is not None
+    has_coordinates = target.bounds is not None
     has_resource_id = target.resource_id is not None and target.resource_id != ""
     has_text = target.text is not None and target.text != ""
     return has_coordinates or has_resource_id or has_text

--- a/minitap/mobile_use/utils/ui_hierarchy.py
+++ b/minitap/mobile_use/utils/ui_hierarchy.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from minitap.mobile_use.utils.logger import get_logger
 
@@ -95,10 +95,10 @@ class Point(BaseModel):
 
 
 class ElementBounds(BaseModel):
-    x: int
-    y: int
-    width: int
-    height: int
+    x: int = Field(description="The x coordinate of the top-left corner of the element.")
+    y: int = Field(description="The y coordinate of the top-left corner of the element.")
+    width: int = Field(description="The width of the element.")
+    height: int = Field(description="The height of the element.")
 
     def get_center(self) -> Point:
         return Point(x=self.x + self.width // 2, y=self.y + self.height // 2)


### PR DESCRIPTION
### 🚀 What's new?

We use the `Target` model for many tools like 'tap', 'long_press', 'focus_and_input_text', ... - where it is meant to reference a UI element. One of its property is `coordinates`, which is misleading because it refers to the bounds of the UI element (i.e. top-left corner X and Y coords with width and height).

Therefore, the LLM sometimes uses the underlying X and Y properties to reference where it wants to click (i.e. center of UI element), but we then work out the center from those coords and the width and height provided which messes everything.

The fix is straightforward: use the correct naming for this property: `coordinates` renamed to `bounds` to avoid ambiguity.

### 🤔 Type of Change

_What kind of change is this? Mark with an `x`_

- [x] **Bug fix** (non-breaking change that solves an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to change)
- [ ] **Documentation** (update to the docs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated docs and examples to reference element "bounds" (x, y, width, height) instead of "coordinates"; added field descriptions for bounds.

* **Refactor**
  * Switched tap and long-press targeting to use bounds across tools, utilities, and examples; interaction center calculations updated accordingly.

* **Bug Fixes**
  * Error and fallback messages updated to reference bounds and "stale bounds" for clearer failure diagnostics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->