### PR TITLE
feat(physical-ios): manage browserstack session

### DIFF
--- a/minitap/mobile_use/clients/browserstack_client.py
+++ b/minitap/mobile_use/clients/browserstack_client.py
@@ -1,0 +1,477 @@
+import asyncio
+from functools import wraps
+from typing import Any
+
+from appium.options.common.base import AppiumOptions
+from appium.webdriver.webdriver import WebDriver
+from selenium.webdriver.common.actions import interaction
+from selenium.webdriver.common.actions.action_builder import ActionBuilder
+from selenium.webdriver.common.actions.pointer_input import PointerInput
+
+from minitap.mobile_use.clients.idb_client import IOSAppInfo
+from minitap.mobile_use.clients.ios_client_config import BrowserStackClientConfig
+from minitap.mobile_use.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+BROWSERSTACK_HUB_URL = "https://hub-cloud.browserstack.com/wd/hub"
+
+
+def with_browserstack_client(func):
+    """Decorator to handle BrowserStack client error handling.
+
+    Note: Function must have None or bool in return type for error fallback.
+    """
+
+    @wraps(func)
+    async def wrapper(self, *args, **kwargs):
+        method_name = func.__name__
+        try:
+            logger.debug(f"Executing BrowserStack operation: {method_name}...")
+            result = await func(self, *args, **kwargs)
+            logger.debug(f"{method_name} completed successfully")
+            return result
+        except Exception as e:
+            logger.error(f"Failed to {method_name}: {e}")
+            import traceback
+
+            logger.debug(f"Traceback: {traceback.format_exc()}")
+
+            return_type = func.__annotations__.get("return")
+            if return_type is bool:
+                return False
+            return None
+
+    return wrapper
+
+
+class BrowserStackClientWrapper:
+    """Wrapper around Appium WebDriver for BrowserStack iOS device automation.
+
+    This wrapper provides an interface similar to IdbClientWrapper and WdaClientWrapper
+    but uses BrowserStack's cloud infrastructure for physical iOS device automation.
+
+    BrowserStack is used for:
+    - Cloud-based physical iOS devices
+    - CI/CD pipelines requiring real device testing
+    - Cross-device testing without local hardware
+
+    Prerequisites:
+        1. BrowserStack account with App Automate access
+        2. Valid username and access_key
+        3. App uploaded to BrowserStack (app_url)
+
+    Example:
+        config = BrowserStackClientConfig(
+            username="your_username",
+            access_key="your_access_key",
+            device_name="iPhone 14",
+            platform_version="16",
+            app_url="bs://your_app_hash",
+        )
+        wrapper = BrowserStackClientWrapper(config=config)
+        await wrapper.init_client()
+        await wrapper.tap(100, 200)
+        await wrapper.cleanup()
+
+        # Using context manager
+        async with BrowserStackClientWrapper(config=config) as wrapper:
+            await wrapper.tap(100, 200)
+            screenshot = await wrapper.screenshot()
+    """
+
+    def __init__(self, config: BrowserStackClientConfig):
+        """Initialize the BrowserStack client wrapper.
+
+        Args:
+            config: BrowserStack configuration with credentials and device settings
+        """
+        self.config = config
+        self._driver: WebDriver | None = None
+
+    async def init_client(self) -> bool:
+        """Initialize the Appium WebDriver session on BrowserStack.
+
+        Returns:
+            True if session created successfully, False otherwise
+        """
+        try:
+            logger.info(
+                f"Creating BrowserStack session for {self.config.device_name} "
+                f"(iOS {self.config.platform_version})"
+            )
+
+            options = AppiumOptions()
+
+            options.set_capability("platformName", "iOS")
+            options.set_capability("appium:deviceName", self.config.device_name)
+            options.set_capability("appium:platformVersion", self.config.platform_version)
+            options.set_capability("appium:automationName", "XCUITest")
+            options.set_capability("appium:app", self.config.app_url)
+
+            bstack_options: dict[str, Any] = {
+                "userName": self.config.username,
+                "accessKey": self.config.access_key.get_secret_value(),
+                "buildName": self.config.build_name or "mobile-use-session",
+                "sessionName": self.config.session_name or "BrowserStack Session",
+                "debug": True,
+            }
+
+            if self.config.project_name:
+                bstack_options["projectName"] = self.config.project_name
+
+            options.set_capability("bstack:options", bstack_options)
+
+            hub_url = self.config.hub_url or BROWSERSTACK_HUB_URL
+
+            self._driver = await asyncio.to_thread(
+                WebDriver,
+                command_executor=hub_url,
+                options=options,
+            )
+
+            if self._driver:
+                session_id = self._driver.session_id
+                logger.info(f"BrowserStack session created successfully. Session ID: {session_id}")
+                logger.info(
+                    f"View session: https://app-automate.browserstack.com/dashboard/v2/sessions/{session_id}"
+                )
+
+            return True
+
+        except Exception as e:
+            logger.error(f"Failed to create BrowserStack session: {e}")
+            self._driver = None
+            return False
+
+    async def cleanup(self) -> None:
+        """Clean up BrowserStack session and quit the driver."""
+        if self._driver is not None:
+            try:
+                logger.info("Ending BrowserStack session")
+                await asyncio.to_thread(self._driver.quit)
+            except Exception as e:
+                logger.debug(f"Error ending BrowserStack session: {e}")
+            finally:
+                self._driver = None
+
+        logger.debug("BrowserStack client cleanup completed")
+
+    async def __aenter__(self):
+        """Async context manager entry."""
+        if not await self.init_client():
+            raise RuntimeError("Failed to create BrowserStack session")
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        """Async context manager exit."""
+        await self.cleanup()
+        return False
+
+    def _ensure_driver(self) -> WebDriver:
+        """Ensure a valid WebDriver session exists.
+
+        Returns:
+            The WebDriver instance
+
+        Raises:
+            RuntimeError: If no driver is available
+        """
+        if self._driver is None:
+            raise RuntimeError(
+                "BrowserStack session not initialized. "
+                "Call init_client() first or use as context manager."
+            )
+        return self._driver
+
+    @with_browserstack_client
+    async def tap(self, x: int, y: int, duration: float | None = None) -> bool:
+        """Tap at the specified coordinates.
+
+        Args:
+            x: X coordinate
+            y: Y coordinate
+            duration: Optional tap duration in seconds (for long press)
+
+        Returns:
+            True if tap succeeded, False otherwise
+        """
+        driver = self._ensure_driver()
+
+        def perform_tap():
+            finger = PointerInput(interaction.POINTER_TOUCH, "finger")
+            actions = ActionBuilder(driver, mouse=finger)
+            actions.pointer_action.move_to_location(x, y)
+            actions.pointer_action.pointer_down()
+            if duration:
+                actions.pointer_action.pause(duration)
+            actions.pointer_action.pointer_up()
+            actions.perform()
+
+        await asyncio.to_thread(perform_tap)
+        return True
+
+    @with_browserstack_client
+    async def swipe(
+        self,
+        x_start: int,
+        y_start: int,
+        x_end: int,
+        y_end: int,
+        duration: float | None = None,
+    ) -> bool:
+        """Swipe from start coordinates to end coordinates.
+
+        Args:
+            x_start: Starting X coordinate
+            y_start: Starting Y coordinate
+            x_end: Ending X coordinate
+            y_end: Ending Y coordinate
+            duration: Optional swipe duration in seconds
+
+        Returns:
+            True if swipe succeeded, False otherwise
+        """
+        driver = self._ensure_driver()
+
+        swipe_duration = duration or 0.5
+
+        def perform_swipe():
+            finger = PointerInput(interaction.POINTER_TOUCH, "finger")
+            actions = ActionBuilder(driver, mouse=finger)
+            actions.pointer_action.move_to_location(x_start, y_start)
+            actions.pointer_action.pointer_down()
+            actions.pointer_action.pause(swipe_duration)
+            actions.pointer_action.move_to_location(x_end, y_end)
+            actions.pointer_action.pointer_up()
+            actions.perform()
+
+        await asyncio.to_thread(perform_swipe)
+        return True
+
+    @with_browserstack_client
+    async def screenshot(self, output_path: str | None = None) -> bytes | None:
+        """Take a screenshot and return raw image data.
+
+        Args:
+            output_path: Optional path to save the screenshot
+
+        Returns:
+            Raw image data (PNG bytes) or None on failure
+        """
+        driver = self._ensure_driver()
+
+        screenshot_base64 = await asyncio.to_thread(driver.get_screenshot_as_base64)
+
+        import base64
+
+        screenshot_data = base64.b64decode(screenshot_base64)
+
+        if output_path:
+            with open(output_path, "wb") as f:
+                f.write(screenshot_data)
+
+        return screenshot_data
+
+    @with_browserstack_client
+    async def launch(
+        self,
+        bundle_id: str,
+        args: list[str] | None = None,
+        env: dict[str, str] | None = None,
+    ) -> bool:
+        """Launch an application by bundle ID.
+
+        Args:
+            bundle_id: The bundle identifier of the app to launch
+            args: Optional list of arguments to pass to the app (not supported on BrowserStack)
+            env: Optional environment variables for the app (not supported on BrowserStack)
+
+        Returns:
+            True if launch succeeded, False otherwise
+        """
+        driver = self._ensure_driver()
+
+        if args or env:
+            logger.warning(
+                "BrowserStack does not support app launch arguments or environment variables"
+            )
+
+        script = "mobile: launchApp"
+        params = {"bundleId": bundle_id}
+
+        await asyncio.to_thread(driver.execute_script, script, params)
+        return True
+
+    @with_browserstack_client
+    async def terminate(self, bundle_id: str) -> bool:
+        """Terminate an application by bundle ID.
+
+        Args:
+            bundle_id: The bundle identifier of the app to terminate
+
+        Returns:
+            True if termination succeeded, False otherwise
+        """
+        driver = self._ensure_driver()
+
+        script = "mobile: terminateApp"
+        params = {"bundleId": bundle_id}
+
+        await asyncio.to_thread(driver.execute_script, script, params)
+        return True
+
+    @with_browserstack_client
+    async def text(self, text: str) -> bool:
+        """Type text using the keyboard.
+
+        Args:
+            text: The text to type
+
+        Returns:
+            True if text input succeeded, False otherwise
+        """
+        driver = self._ensure_driver()
+
+        active_element = await asyncio.to_thread(lambda: driver.switch_to.active_element)
+        await asyncio.to_thread(active_element.send_keys, text)
+        return True
+
+    @with_browserstack_client
+    async def open_url(self, url: str) -> bool:
+        """Open a URL on the device.
+
+        Args:
+            url: The URL to open
+
+        Returns:
+            True if URL opened successfully, False otherwise
+        """
+        driver = self._ensure_driver()
+
+        await asyncio.to_thread(driver.get, url)
+        return True
+
+    @with_browserstack_client
+    async def key(self, key_code: int) -> bool:
+        """Send a key press.
+
+        Note: Limited key support on BrowserStack/Appium.
+        For delete (key_code=42), we send a backspace.
+
+        Args:
+            key_code: HID key code (42 = delete/backspace)
+
+        Returns:
+            True if key press succeeded, False otherwise
+        """
+        driver = self._ensure_driver()
+
+        if key_code == 42:  # Delete/backspace
+            active_element = await asyncio.to_thread(lambda: driver.switch_to.active_element)
+            current_text = await asyncio.to_thread(lambda: active_element.text)
+            if current_text:
+                await asyncio.to_thread(active_element.clear)
+                await asyncio.to_thread(active_element.send_keys, current_text[:-1])
+        return True
+
+    @with_browserstack_client
+    async def button(self, button_type: Any) -> bool:
+        """Press a hardware button (compatible with IDB's HIDButtonType).
+
+        Args:
+            button_type: Button type (HIDButtonType.HOME, etc.)
+
+        Returns:
+            True if button press succeeded, False otherwise
+        """
+        driver = self._ensure_driver()
+
+        button_name = getattr(button_type, "name", str(button_type)).lower()
+
+        if button_name == "home":
+            script = "mobile: pressButton"
+            params = {"name": "home"}
+            await asyncio.to_thread(driver.execute_script, script, params)
+        elif button_name in ("volume_up", "volumeup"):
+            script = "mobile: pressButton"
+            params = {"name": "volumeUp"}
+            await asyncio.to_thread(driver.execute_script, script, params)
+        elif button_name in ("volume_down", "volumedown"):
+            script = "mobile: pressButton"
+            params = {"name": "volumeDown"}
+            await asyncio.to_thread(driver.execute_script, script, params)
+
+        return True
+
+    async def describe_all(self) -> list[dict[str, Any]] | None:
+        """Get UI hierarchy as a flat list (compatible with IDB's describe_all).
+
+        Returns:
+            List of UI elements or None on error
+        """
+        try:
+            driver = self._ensure_driver()
+            page_source = await asyncio.to_thread(lambda: driver.page_source)
+            if page_source is None:
+                return None
+            return self._parse_xml_to_elements(page_source)
+        except Exception as e:
+            logger.error(f"Failed to describe_all: {e}")
+            return None
+
+    def _parse_xml_to_elements(self, xml_source: str) -> list[dict[str, Any]]:
+        """Parse Appium XML source into flat element list matching IDB format."""
+        import xml.etree.ElementTree as ET
+
+        elements = []
+        try:
+            root = ET.fromstring(xml_source)
+            for elem in root.iter():
+                if elem.tag == "AppiumAUT":
+                    continue
+                frame = {
+                    "x": float(elem.get("x", 0)),
+                    "y": float(elem.get("y", 0)),
+                    "width": float(elem.get("width", 0)),
+                    "height": float(elem.get("height", 0)),
+                }
+                element = {
+                    "type": elem.get("type", elem.tag),
+                    "value": elem.get("value", ""),
+                    "label": elem.get("label", elem.get("name", "")),
+                    "frame": frame,
+                    "enabled": elem.get("enabled", "false").lower() == "true",
+                    "visible": elem.get("visible", "true").lower() == "true",
+                }
+                elements.append(element)
+        except ET.ParseError as e:
+            logger.error(f"Failed to parse XML: {e}")
+        return elements
+
+    async def app_current(self) -> IOSAppInfo | None:
+        """Get information about the currently active app.
+
+        Note: BrowserStack doesn't support activeAppInfo script directly.
+        Returns None as this feature is not available on BrowserStack.
+
+        Returns:
+            None (not supported on BrowserStack)
+        """
+        logger.debug("app_current is not supported on BrowserStack")
+        return None
+
+    async def install(self, app_path: str) -> list[Any]:
+        """Install an app (not supported on BrowserStack - apps must be pre-uploaded).
+
+        Args:
+            app_path: Path to the app (ignored)
+
+        Returns:
+            Empty list with warning
+        """
+        logger.warning(
+            "App installation not supported on BrowserStack. "
+            "Please upload your app to BrowserStack first and use the app_url in config."
+        )
+        return []

--- a/minitap/mobile_use/clients/ios_client_config.py
+++ b/minitap/mobile_use/clients/ios_client_config.py
@@ -1,8 +1,55 @@
 from __future__ import annotations
 
-from dataclasses import replace
+from pydantic import BaseModel, ConfigDict, SecretStr
 
-from pydantic import BaseModel, ConfigDict
+
+class BrowserStackClientConfig(BaseModel):
+    model_config = ConfigDict(frozen=True)
+    username: str
+    access_key: SecretStr
+    device_name: str
+    platform_version: str
+    app_url: str
+    hub_url: str | None = None
+    project_name: str | None = None
+    build_name: str | None = None
+    session_name: str | None = None
+
+    @classmethod
+    def with_overrides(
+        cls,
+        username: str | None = None,
+        access_key: str | None = None,
+        device_name: str | None = None,
+        platform_version: str | None = None,
+        app_url: str | None = None,
+        hub_url: str | None = None,
+        project_name: str | None = None,
+        build_name: str | None = None,
+        session_name: str | None = None,
+        base: BrowserStackClientConfig | None = None,
+    ) -> BrowserStackClientConfig:
+        """Create a BrowserStackClientConfig with only specified fields overridden."""
+        if base is None:
+            raise ValueError("base config is required for BrowserStackClientConfig.with_overrides")
+        overrides = {
+            k: v
+            for k, v in {
+                "username": username,
+                "access_key": access_key,
+                "device_name": device_name,
+                "platform_version": platform_version,
+                "app_url": app_url,
+                "hub_url": hub_url,
+                "project_name": project_name,
+                "build_name": build_name,
+                "session_name": session_name,
+            }.items()
+            if v is not None
+        }
+        if not overrides:
+            return base
+        return base.model_copy(update=overrides)
 
 
 class WdaClientConfig(BaseModel):
@@ -47,7 +94,7 @@ class WdaClientConfig(BaseModel):
         }
         if not overrides:
             return base
-        return replace(base, **overrides)
+        return base.model_copy(update=overrides)
 
 
 class IdbClientConfig(BaseModel):
@@ -66,23 +113,29 @@ class IdbClientConfig(BaseModel):
         overrides = {k: v for k, v in {"host": host, "port": port}.items() if v is not None}
         if not overrides:
             return base
-        return replace(base, **overrides)
+        return base.model_copy(update=overrides)
 
 
 class IosClientConfig(BaseModel):
     model_config = ConfigDict(frozen=True)
     wda: WdaClientConfig = WdaClientConfig()
     idb: IdbClientConfig = IdbClientConfig()
+    browserstack: BrowserStackClientConfig | None = None
 
     @classmethod
     def with_overrides(
         cls,
         wda: WdaClientConfig | None = None,
         idb: IdbClientConfig | None = None,
+        browserstack: BrowserStackClientConfig | None = None,
     ) -> IosClientConfig:
         """Create an IosClientConfig with only specified fields overridden."""
         base = cls()
-        overrides = {k: v for k, v in {"wda": wda, "idb": idb}.items() if v is not None}
+        overrides = {
+            k: v
+            for k, v in {"wda": wda, "idb": idb, "browserstack": browserstack}.items()
+            if v is not None
+        }
         if not overrides:
             return base
-        return replace(base, **overrides)
+        return base.model_copy(update=overrides)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "uiautomator2>=3.5.0",
     "fb-idb==1.1.7",
     "facebook-wda>=1.5.4",
+    "Appium-Python-Client>=5.0.0",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -66,6 +66,19 @@ wheels = [
 ]
 
 [[package]]
+name = "appium-python-client"
+version = "5.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "selenium" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/c5/27f5768feb757a9e8a77b4c1681bae4a2be3117e654ba4fe0e1fc3c45cee/appium_python_client-5.2.4.tar.gz", hash = "sha256:eafeee9ff1ad8ac3052d2f706dca5cb52ebf51b5335f1f7102c71a663ee18c13", size = 212484 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/48/758bea06efad9c32eab0ade089d5fea230bb5009921a7d6de8564b98585e/appium_python_client-5.2.4-py3-none-any.whl", hash = "sha256:1c8ccdc1b6e5c88e9835f4d81d338cae574e74114a85d5ffaa049d9b0fb4c32a", size = 348622 },
+]
+
+[[package]]
 name = "attrs"
 version = "25.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1432,6 +1445,7 @@ version = "3.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "adbutils" },
+    { name = "appium-python-client" },
     { name = "colorama" },
     { name = "facebook-wda" },
     { name = "fastapi" },
@@ -1477,6 +1491,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "adbutils", specifier = "==2.9.3" },
+    { name = "appium-python-client", specifier = ">=5.0.0" },
     { name = "colorama", specifier = ">=0.4.6" },
     { name = "facebook-wda", specifier = ">=1.5.4" },
     { name = "fastapi", specifier = "==0.111.0" },
@@ -1798,6 +1813,18 @@ wheels = [
 ]
 
 [[package]]
+name = "outcome"
+version = "1.3.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/df/77698abfac98571e65ffeb0c1fba8ffd692ab8458d617a0eed7d9a8d38f2/outcome-1.3.0.post0.tar.gz", hash = "sha256:9dcf02e65f2971b80047b377468e72a268e15c0af3cf1238e6ff14f7f91143b8", size = 21060 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/8b/5ab7257531a5d830fc8000c476e63c935488d74609b50f9384a643ec0a62/outcome-1.3.0.post0-py2.py3-none-any.whl", hash = "sha256:e771c5ce06d1415e356078d3bdd68523f284b4ce5419828922b6871e65eda82b", size = 10692 },
+]
+
+[[package]]
 name = "packaging"
 version = "24.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2105,6 +2132,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fb/6c/ba4bbee22e76af700ea593a1d8701e3225080956753bee9750dcc25e2649/pyright-1.1.405.tar.gz", hash = "sha256:5c2a30e1037af27eb463a1cc0b9f6d65fec48478ccf092c1ac28385a15c55763", size = 4068319 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d5/1a/524f832e1ff1962a22a1accc775ca7b143ba2e9f5924bb6749dce566784a/pyright-1.1.405-py3-none-any.whl", hash = "sha256:a2cb13700b5508ce8e5d4546034cb7ea4aedb60215c6c33f56cec7f53996035a", size = 5905038 },
+]
+
+[[package]]
+name = "pysocks"
+version = "1.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/11/293dd436aea955d45fc4e8a35b6ae7270f5b8e00b53cf6c024c83b657a11/PySocks-1.7.1.tar.gz", hash = "sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0", size = 284429 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/59/b4572118e098ac8e46e399a1dd0f2d85403ce8bbaad9ec79373ed6badaf9/PySocks-1.7.1-py3-none-any.whl", hash = "sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5", size = 16725 },
 ]
 
 [[package]]
@@ -2486,6 +2522,23 @@ wheels = [
 ]
 
 [[package]]
+name = "selenium"
+version = "4.36.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "trio" },
+    { name = "trio-websocket" },
+    { name = "typing-extensions" },
+    { name = "urllib3", extra = ["socks"] },
+    { name = "websocket-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/35/33d3d84e3399c9d00b489aeccfdc78115e149e45816fb8fe84274329e8a2/selenium-4.36.0.tar.gz", hash = "sha256:0eced83038736c3a013b824116df0b6dbb83e93721545f51b680451013416723", size = 913613 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/9e/642a355e43a4ebf68bc4f00dd4ab264f635079c5dc7ed6d9991a0c2be3d7/selenium-4.36.0-py3-none-any.whl", hash = "sha256:525fdfe96b99c27d9a2c773c75aa7413f4c24bdb7b9749c1950aa3b5f79ed915", size = 9587029 },
+]
+
+[[package]]
 name = "shapely"
 version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2545,6 +2598,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575 },
 ]
 
 [[package]]
@@ -2667,6 +2729,37 @@ wheels = [
 ]
 
 [[package]]
+name = "trio"
+version = "0.32.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "cffi", marker = "implementation_name != 'pypy' and os_name == 'nt'" },
+    { name = "idna" },
+    { name = "outcome" },
+    { name = "sniffio" },
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d8/ce/0041ddd9160aac0031bcf5ab786c7640d795c797e67c438e15cfedf815c8/trio-0.32.0.tar.gz", hash = "sha256:150f29ec923bcd51231e1d4c71c7006e65247d68759dd1c19af4ea815a25806b", size = 605323 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/bf/945d527ff706233636c73880b22c7c953f3faeb9d6c7e2e85bfbfd0134a0/trio-0.32.0-py3-none-any.whl", hash = "sha256:4ab65984ef8370b79a76659ec87aa3a30c5c7c83ff250b4de88c29a8ab6123c5", size = 512030 },
+]
+
+[[package]]
+name = "trio-websocket"
+version = "0.12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "outcome" },
+    { name = "trio" },
+    { name = "wsproto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/3c/8b4358e81f2f2cfe71b66a267f023a91db20a817b9425dd964873796980a/trio_websocket-0.12.2.tar.gz", hash = "sha256:22c72c436f3d1e264d0910a3951934798dcc5b00ae56fc4ee079d46c7cf20fae", size = 33549 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/19/eb640a397bba49ba49ef9dbe2e7e5c04202ba045b6ce2ec36e9cadc51e04/trio_websocket-0.12.2-py3-none-any.whl", hash = "sha256:df605665f1db533f4a386c94525870851096a223adcb97f72a07e8b4beba45b6", size = 21221 },
+]
+
+[[package]]
 name = "typer"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2753,6 +2846,11 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795 },
+]
+
+[package.optional-dependencies]
+socks = [
+    { name = "pysocks" },
 ]
 
 [[package]]
@@ -2899,6 +2997,15 @@ wheels = [
 ]
 
 [[package]]
+name = "websocket-client"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616 },
+]
+
+[[package]]
 name = "websockets"
 version = "15.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2976,6 +3083,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/79/d9/7cfd5a312760ac4dd8bf0184a6ee9e43c33e47f3dadc303032ce012b8fa3/wrapt-1.17.3-cp314-cp314t-win_amd64.whl", hash = "sha256:73d496de46cd2cdbdbcce4ae4bcdb4afb6a11234a1df9c085249d55166b95116", size = 41334 },
     { url = "https://files.pythonhosted.org/packages/46/78/10ad9781128ed2f99dbc474f43283b13fea8ba58723e98844367531c18e9/wrapt-1.17.3-cp314-cp314t-win_arm64.whl", hash = "sha256:f38e60678850c42461d4202739f9bf1e3a737c7ad283638251e79cc49effb6b6", size = 38471 },
     { url = "https://files.pythonhosted.org/packages/1f/f6/a933bd70f98e9cf3e08167fc5cd7aaaca49147e48411c0bd5ae701bb2194/wrapt-1.17.3-py3-none-any.whl", hash = "sha256:7171ae35d2c33d326ac19dd8facb1e82e5fd04ef8c6c0e394d7af55a55051c22", size = 23591 },
+]
+
+[[package]]
+name = "wsproto"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/79/12135bdf8b9c9367b8701c2c19a14c913c120b882d50b014ca0d38083c2c/wsproto-1.3.2.tar.gz", hash = "sha256:b86885dcf294e15204919950f666e06ffc6c7c114ca900b060d6e16293528294", size = 50116 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/f5/10b68b7b1544245097b2a1b8238f66f2fc6dcaeb24ba5d917f52bd2eed4f/wsproto-1.3.2-py3-none-any.whl", hash = "sha256:61eea322cdf56e8cc904bd3ad7573359a242ba65688716b0710a5eb12beab584", size = 24405 },
 ]
 
 [[package]]


### PR DESCRIPTION
### 🚀 What's new?

_Add the ability to manage BrowserStack session to support of iOS physical device in the cloud_

### 🤔 Type of Change

_What kind of change is this? Mark with an `x`_

- [ ] **Bug fix** (non-breaking change that solves an issue)
- [x] **New feature** (non-breaking change that adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to change)
- [ ] **Documentation** (update to the docs)

### ✅ Checklist

_Before you submit, please make sure you've done the following. If you have any questions, we're here to help!_

- [ ] I have read the **[Contributing Guide](../CONTRIBUTING.md)**.
- [ ] My code follows the project's style guidelines (`ruff check .` and `ruff format .` pass).
- [ ] I have added necessary documentation (if applicable).

### 💬 Any questions or comments?

_Have a question or need some help? Join us on **[Discord](https://discord.gg/6nSqmQ9pQs)**!_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * BrowserStack-based iOS automation added for remote device testing without a local UDID.
  * Remote client provides async lifecycle, context-manager support, and common mobile actions (tap, swipe, screenshots, launch/terminate, text input, open URL, key/button events, UI element listing).

* **Chores**
  * Added Appium Python client dependency.
  * Added BrowserStack configuration options to iOS client settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->