### PR TITLE
feat(utils/media): USE_FFMPEG_GIF env var to generate the trajectory using ffmpeg for memory efficiency

### DIFF
--- a/minitap/mobile_use/utils/media.py
+++ b/minitap/mobile_use/utils/media.py
@@ -1,50 +1,146 @@
 import json
+import os
+import subprocess
+import tempfile
 from pathlib import Path
 
 from PIL import Image
 
+USE_FFMPEG_GIF = os.environ.get("USE_FFMPEG_GIF", "").lower() in ("1", "true", "yes")
 
-def quantize_and_save_gif(
-    images: list[Image.Image],
+
+def quantize_and_save_gif_from_paths(
+    image_paths: list[Path],
     output_path: Path,
     colors: int = 128,
     duration: int = 100,
 ) -> None:
     """
-    Quantize images and save as an optimized GIF.
+    Create an optimized GIF from image file paths.
+
+    By default uses PIL (loads all frames into memory).
+    Set USE_FFMPEG_GIF=1 env var to use ffmpeg for memory-efficient streaming.
 
     Args:
-        images: List of PIL Image objects to convert to GIF
+        image_paths: List of paths to image files (must be sorted in desired order)
         output_path: Path where the GIF will be saved
         colors: Number of colors to use in quantization (lower = smaller file)
         duration: Duration of each frame in milliseconds
 
     Raises:
-        ValueError: If images list is empty
+        ValueError: If image_paths list is empty
+        RuntimeError: If ffmpeg fails (when USE_FFMPEG_GIF is enabled)
     """
-    if not images:
-        raise ValueError("images must not be empty")
+    if not image_paths:
+        raise ValueError("image_paths must not be empty")
 
-    quantized_images = []
-    for img in images:
-        if img.mode != "RGB":
-            img = img.convert("RGB")
-        quantized = img.quantize(colors=colors, method=2)
-        quantized_images.append(quantized)
+    if USE_FFMPEG_GIF:
+        _save_gif_ffmpeg(image_paths, output_path, colors, duration)
+    else:
+        _save_gif_pillow(image_paths, output_path, colors, duration)
 
-    quantized_images[0].save(
+
+def _save_gif_pillow(
+    image_paths: list[Path],
+    output_path: Path,
+    colors: int,
+    duration: int,
+) -> None:
+    """Create GIF using PIL (loads all frames into memory)."""
+
+    def frame_generator():
+        for path in image_paths:
+            with Image.open(path) as img:
+                if img.mode != "RGB":
+                    img = img.convert("RGB")
+                yield img.quantize(colors=colors, method=2)
+
+    frames = frame_generator()
+    first_frame = next(frames)
+    first_frame.save(
         output_path,
         save_all=True,
-        append_images=quantized_images[1:],
+        append_images=frames,
         loop=0,
         optimize=True,
         duration=duration,
     )
 
 
+def _save_gif_ffmpeg(
+    image_paths: list[Path],
+    output_path: Path,
+    colors: int,
+    duration: int,
+) -> None:
+    """Create GIF using ffmpeg (memory-efficient streaming)."""
+    fps = 1000 / duration
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+        for i, path in enumerate(image_paths):
+            f.write(f"file '{path.absolute()}'\n")
+            # Last file needs no duration (ffmpeg concat demuxer uses it as the final frame)
+            if i < len(image_paths) - 1:
+                f.write(f"duration {duration / 1000}\n")
+        # Repeat last file to ensure it's included (ffmpeg concat demuxer quirk)
+        f.write(f"file '{image_paths[-1].absolute()}'\n")
+        concat_file = Path(f.name)
+
+    palette_path = output_path.with_suffix(".palette.png")
+
+    try:
+        result = subprocess.run(
+            [
+                "ffmpeg",
+                "-y",
+                "-f",
+                "concat",
+                "-safe",
+                "0",
+                "-i",
+                str(concat_file),
+                "-vf",
+                f"palettegen=max_colors={min(colors, 256)}:stats_mode=diff",
+                str(palette_path),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"ffmpeg palette generation failed: {result.stderr}")
+
+        result = subprocess.run(
+            [
+                "ffmpeg",
+                "-y",
+                "-f",
+                "concat",
+                "-safe",
+                "0",
+                "-i",
+                str(concat_file),
+                "-i",
+                str(palette_path),
+                "-lavfi",
+                f"fps={fps},paletteuse=dither=bayer:bayer_scale=5",
+                "-loop",
+                "0",
+                str(output_path),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"ffmpeg GIF creation failed: {result.stderr}")
+
+    finally:
+        concat_file.unlink(missing_ok=True)
+        if palette_path.exists():
+            palette_path.unlink()
+
+
 def create_gif_from_trace_folder(trace_folder_path: Path):
-    images = []
-    image_files = []
+    image_files: list[Path] = []
 
     for file in trace_folder_path.iterdir():
         if file.suffix == ".jpeg":
@@ -52,19 +148,14 @@ def create_gif_from_trace_folder(trace_folder_path: Path):
 
     image_files.sort(key=lambda f: int(f.stem))
 
-    print("Found " + str(len(image_files)) + " images to compile")
+    print(f"Found {len(image_files)} images to compile")
 
-    for file in image_files:
-        with open(file, "rb") as f:
-            image = Image.open(f).convert("RGB")
-            images.append(image)
-
-    if len(images) == 0:
+    if not image_files:
         return
 
     gif_path = trace_folder_path / "trace.gif"
-    quantize_and_save_gif(images, gif_path)
-    print("GIF created at " + str(gif_path))
+    quantize_and_save_gif_from_paths(image_files, gif_path)
+    print(f"GIF created at {gif_path}")
 
 
 def remove_images_from_trace_folder(trace_folder_path: Path):


### PR DESCRIPTION
Unfortunately there is no lazy loading of images when creating a GIF using PIL even using a frame generator.

Therefore, I added an environment variable to opt in using ffmpeg binary to compute the GIF trajectory which is memory efficient.  

I intentionally didn't add the new env var inside the `config.py` but I can do that if required - I feel like it's mostly something internal and which requires ffmpeg to be installed on the user machine. Tell me what you think about that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured GIF creation process to support multiple processing backends, enabling improved performance flexibility

* **Bug Fixes**
  * Enhanced input validation with clearer error messages for invalid image inputs during GIF creation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->