### PR TITLE
fix: normalizing input for press key tool

### DIFF
--- a/minitap/mobile_use/tools/mobile/press_key.py
+++ b/minitap/mobile_use/tools/mobile/press_key.py
@@ -6,6 +6,7 @@ from langchain_core.tools import tool
 from langchain_core.tools.base import InjectedToolCallId
 from langgraph.prebuilt import InjectedState
 from langgraph.types import Command
+from pydantic import BeforeValidator
 
 from minitap.mobile_use.constants import EXECUTOR_MESSAGES_KEY
 from minitap.mobile_use.context import MobileUseContext
@@ -20,11 +21,21 @@ class Key(Enum):
     BACK = "Back"
 
 
+def normalize_key(value: str | Key) -> str:
+    """Convert key input to Title Case for case-insensitive matching."""
+    if isinstance(value, Key):
+        return value.value
+    return value.title()
+
+
+CaseInsensitiveKey = Annotated[Key, BeforeValidator(normalize_key)]
+
+
 def get_press_key_tool(ctx: MobileUseContext):
     @tool
     async def press_key(
         agent_thought: str,
-        key: Key,
+        key: CaseInsensitiveKey,
         tool_call_id: Annotated[str, InjectedToolCallId],
         state: Annotated[State, InjectedState],
     ) -> Command:


### PR DESCRIPTION
### 🚀 What's new?

Pydantic Enum validation is strictly case-sensitive. Only the exact value "Enter" was accepted.

As a result:

"Enter" → ✅ Works
"enter" → ❌ ValidationError
"ENTER" → ❌ ValidationError

When the LLM returned "enter" or "ENTER", it triggered a ValidationError, causing the ExecutorToolNode to fail.

Now, when we recieve Enter, enter, ENTER, it will be changed to the expected input.

### 🤔 Type of Change

_What kind of change is this? Mark with an `x`_

- [ ] **Bug fix** (non-breaking change that solves an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to change)
- [ ] **Documentation** (update to the docs)

### ✅ Checklist

_Before you submit, please make sure you've done the following. If you have any questions, we're here to help!_

- [ ] I have read the **[Contributing Guide](../CONTRIBUTING.md)**.
- [ ] My code follows the project's style guidelines (`ruff check .` and `ruff format .` pass).
- [ ] I have added necessary documentation (if applicable).

### 💬 Any questions or comments?

_Have a question or need some help? Join us on **[Discord](https://discord.gg/6nSqmQ9pQs)**!_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* The key press function now accepts key inputs in any case format. Whether you use lowercase, uppercase, or mixed-case entries (e.g., "enter", "ENTER", "Enter"), the system automatically normalizes and processes them correctly, improving usability and reducing input errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->