### PR TITLE
chore: rename MINITAP_BASE_URL from mobile-use.ai to minitap.ai

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 MINITAP_API_KEY="..."
-# MINITAP_BASE_URL="https://platform.mobile-use.ai" # Optional - uncomment to override default
+# MINITAP_BASE_URL="https://platform.minitap.ai" # Optional - uncomment to override default
 
 OPENAI_API_KEY='...'
 # OPENAI_BASE_URL="https://api.openai.com/v1" # Optional - uncomment to override default

--- a/minitap/mobile_use/config.py
+++ b/minitap/mobile_use/config.py
@@ -26,7 +26,7 @@ class Settings(BaseSettings):
     MINITAP_API_KEY: SecretStr | None = None
 
     OPENAI_BASE_URL: str | None = None
-    MINITAP_BASE_URL: str = "https://platform.mobile-use.ai"
+    MINITAP_BASE_URL: str = "https://platform.minitap.ai"
 
     ADB_HOST: str | None = None
     ADB_PORT: int | None = None


### PR DESCRIPTION
## Summary

- Renames the default `MINITAP_BASE_URL` from `https://platform.mobile-use.ai` to `https://platform.minitap.ai`
- Updates both `config.py` and `.env.example` to reflect the new URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default API endpoint URL to platform.minitap.ai.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->