### PR TITLE
feat: encrypt secrets in .env.example with dotenvx

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,15 +1,24 @@
-MINITAP_API_KEY="..."
-# MINITAP_BASE_URL="https://platform.minitap.ai" # Optional - uncomment to override default
+# ──────────────────────────────────────────────
+# mobile-use
+# Active config targets LOCAL DEVELOPMENT
+# ──────────────────────────────────────────────
 
-OPENAI_API_KEY='...'
-# OPENAI_BASE_URL="https://api.openai.com/v1" # Optional - uncomment to override default
+# LLM API Keys (personal — uncomment the ones you use)
+# GOOGLE_API_KEY="<your-key-here>"
+# OPENAI_API_KEY="<your-key-here>"
+# XAI_API_KEY="<your-key-here>"
+# OPEN_ROUTER_API_KEY="<your-key-here>"
 
-GOOGLE_API_KEY="..."
-XAI_API_KEY='...'
-OPEN_ROUTER_API_KEY='..'
+# Minitap Platform
+MINITAP_API_KEY="<your-key-here>"
+# MINITAP_BASE_URL="https://platform.minitap.ai"
 
-# EVENTS_OUTPUT_PATH="./events.txt" # Optional - path to output events file
-# RESULTS_OUTPUT_PATH="./results.txt" # Optional - path to output results file
+# Lim
+LIM_API_KEY="<your-key-here>"
 
-# Telemetry - set to "false" to disable anonymous usage data collection
+# Output Paths (optional)
+# EVENTS_OUTPUT_PATH="./events.txt"
+# RESULTS_OUTPUT_PATH="./results.txt"
+
+# Telemetry — set to "false" to disable anonymous usage data collection
 # MOBILE_USE_TELEMETRY_ENABLED="true"


### PR DESCRIPTION
Secrets in `.env.example` are now encrypted inline using [dotenvx](https://dotenvx.com/) (secp256k1 ECIES + AES-256-GCM). Non-secret values remain plaintext and readable