### PR TITLE
Add EclawController passthrough + community-controllers README entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,14 @@ _This diagram is automatically updated from the codebase. This is our current ag
 
 </div>
 
+## 🔌 Community controllers
+
+mobile-use ships with first-party controllers for Android (adb / UIAutomator), iOS (idb / WDA), and Limrun. Out-of-tree controllers implement the same `MobileDeviceController` Protocol and ship as separate PyPI packages:
+
+- **EClawbot** (`pip install eclaw-mobile-use-driver`) — drives any device that has the [EClaw](https://eclawbot.com) app installed, over HTTPS, with no adb/idb access required on the caller machine. Useful for real-device + global reach. Source: [HankHuang0516/EClaw / eclaw-mobile-use-driver](https://github.com/HankHuang0516/EClaw/tree/main/eclaw-mobile-use-driver). Spec: [mobile-use-integration.md](https://github.com/HankHuang0516/EClaw/blob/main/docs/specs/mobile-use-integration.md). Import shim — `from minitap.mobile_use.controllers.eclaw_controller import EclawController`.
+
+PRs adding new entries to this list are welcome — keep the driver package out-of-tree (so upstream stays slim and release coordination stays decoupled) and contribute only the documentation pointer + optional one-file import shim under `minitap/mobile_use/controllers/`.
+
 ## ❤️ Contributing
 
 We love contributions! Whether you're fixing a bug, adding a feature, or improving documentation, your help is welcome. Please read our **[Contributing Guidelines](CONTRIBUTING.md)** to get started.

--- a/minitap/mobile_use/controllers/eclaw_controller.py
+++ b/minitap/mobile_use/controllers/eclaw_controller.py
@@ -1,0 +1,56 @@
+"""EClaw controller — passthrough to the out-of-tree
+``eclaw-mobile-use-driver`` package.
+
+This module is a thin import shim so users can write
+``from minitap.mobile_use.controllers.eclaw_controller import EclawController``
+the same way they import :class:`AndroidDeviceController` and
+:class:`iOSDeviceController`, while the actual implementation lives in a
+separately versioned PyPI package maintained by the EClawbot team.
+
+Install
+-------
+    pip install eclaw-mobile-use-driver
+
+Usage
+-----
+    from minitap.mobile_use.controllers.eclaw_controller import EclawController
+
+    controller = EclawController(
+        device_id="<eclaw-device-uuid>",
+        bot_secret="<32-hex botSecret>",
+        entity_id=2,
+    )
+
+``EclawController`` implements the
+:class:`MobileDeviceController` Protocol against the EClawbot HTTPS control
+API (``/api/device/control`` + ``/api/device/screen-image``), which lets
+the mobile-use LangGraph drive any phone where the user has installed the
+EClaw app and toggled ``remote_control_enabled`` on. iOS coverage in v1 is
+limited to the in-app WebView shim — native iOS apps are out of scope
+until the EClaw side adopts ``idb-companion``.
+
+References
+----------
+- Driver source / issue tracker:
+  https://github.com/HankHuang0516/EClaw/tree/main/eclaw-mobile-use-driver
+- Integration spec:
+  https://github.com/HankHuang0516/EClaw/blob/main/docs/specs/mobile-use-integration.md
+- Discussion / interest probe:
+  https://github.com/minitap-ai/mobile-use/issues/199
+"""
+
+from __future__ import annotations
+
+try:
+    from eclaw_mobile_use_driver import EclawController  # type: ignore[import-not-found]
+except ImportError as _exc:  # pragma: no cover — import-time guidance only.
+    raise ImportError(
+        "EclawController is provided by the external `eclaw-mobile-use-driver` "
+        "package. Install it with:\n\n"
+        "    pip install eclaw-mobile-use-driver\n\n"
+        "See https://github.com/HankHuang0516/EClaw/tree/main/eclaw-mobile-use-driver "
+        "for source, license (MIT), and the integration spec."
+    ) from _exc
+
+
+__all__ = ["EclawController"]


### PR DESCRIPTION
Follow-up to the interest probe in #199 — opening this as the **wrapper PR** spec'd at https://github.com/HankHuang0516/EClaw/blob/main/docs/specs/mobile-use-integration.md §5.4 so reviewers have something concrete to look at. Totally fine to drop / rework anything you'd rather keep out of tree — the driver itself ships independently.

## What this PR adds

- **`minitap/mobile_use/controllers/eclaw_controller.py`** (50 lines)
  A thin import shim that re-exports `EclawController` from the external
  `eclaw-mobile-use-driver` PyPI package. Raises `ImportError` with install
  instructions if the optional package isn't on `sys.path`. **No new runtime
  dep added to mobile-use itself.**

- **README — new "Community controllers" section**
  Above Contributing, with EClawbot as the first entry and a one-line
  process note for future contributors ("keep the driver package out-of-tree;
  contribute only the documentation pointer + optional one-file import shim").

## What this PR does **not** add

- No vendored EClaw source. The wrapper is purely a discoverability hook.
- No new test-runtime dep. The shim raises a clear ImportError when the
  optional package isn't installed; `pyproject.toml` is unchanged.
- No changes to any existing controller or LangGraph layer.

## The driver (separate repo)

Lives at https://github.com/HankHuang0516/EClaw/tree/main/eclaw-mobile-use-driver — MIT-licensed, separately versioned, ~370 LoC controller + 156 LoC transport + 34 mocked unit tests. Implements all 18 methods of `MobileDeviceController` against the EClawbot HTTPS control API (`/api/device/control` + `/api/device/screen-image`).

Local-repo PR landing the driver: https://github.com/HankHuang0516/EClaw/pull/3128.

## Why ship it as community / out-of-tree?

From the integration spec §5.4:
> Upstream churns fast (10 releases since 2025; latest Jan 2026). Bundling our adapter inside their tree adds release coordination overhead. mobile-use's DeviceController is a stable Python interface; extensions can ship out-of-tree.

This PR is the minimum surface we'd ask of upstream — a discoverability shim + a README line — so the LangGraph user community knows the option exists without you having to take on release coordination for our adapter.

## Test plan

- Import the shim with the optional package installed → returns `EclawController` from the driver package.
- Import the shim without the optional package → raises `ImportError` with the `pip install eclaw-mobile-use-driver` hint.
- README renders cleanly on GitHub (verified locally).

Thanks for considering — happy to iterate or close if this isn't the right venue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for EClawbot integration as a community controller.
  * Helpful setup guidance provided when dependencies are missing.

* **Documentation**
  * Added "Community controllers" section to README documenting out-of-tree controller approach and EClawbot integration.
  * Included contribution guidelines for future community controller additions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->