### PR TITLE
docs: fix incorrect main.py path in Usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ To run mobile-use, simply pass your command as an argument.
 **Example 1: Basic Command**
 
 ```bash
-python ./src/mobile_use/main.py "Go to settings and tell me my current battery level"
+python ./minitap/mobile_use/main.py "Go to settings and tell me my current battery level"
 ```
 
 **Example 2: Data Scraping**
@@ -238,7 +238,7 @@ python ./src/mobile_use/main.py "Go to settings and tell me my current battery l
 Extract specific information and get it back in a structured format. For instance, to get a list of your unread emails:
 
 ```bash
-python ./src/mobile_use/main.py \
+python ./minitap/mobile_use/main.py \
   "Open Gmail, find all unread emails, and list their sender and subject line" \
   --output-description "A JSON list of objects, each with 'sender' and 'subject' keys"
 ```


### PR DESCRIPTION
﻿## Summary

Fixes #196 — two Usage examples in the README referenced `./src/mobile_use/main.py`, which does not exist in the repository. The actual path is `./minitap/mobile_use/main.py`.

## Changes

- Example 1 (Basic Command): `./src/mobile_use/main.py` → `./minitap/mobile_use/main.py`
- Example 2 (Data Scraping): same fix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated command-line interface examples to reference the correct entry point and improved formatting for command arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->