### PR TITLE
fix: resolve bundle ID on non-English iOS simulator locales via CFBundleLocalizedName

### DIFF
--- a/minitap/mobile_use/clients/idb_client.py
+++ b/minitap/mobile_use/clients/idb_client.py
@@ -385,10 +385,12 @@ class IdbClientWrapper:
                     current_bundle_id = bundle_match.group(1)
                     continue
 
-                # Match display name: CFBundleDisplayName = AppName; (no quotes)
-                # or CFBundleName = AppName;
+                # Match display name: CFBundleDisplayName, CFBundleLocalizedName,
+                # or CFBundleName — include localized variant so non-English
+                # simulator locales (where AXLabel returns the localized name)
+                # still resolve to the correct bundle ID.
                 if current_bundle_id:
-                    name_match = re.match(r"CFBundle(?:Display)?Name\s*=\s*([^;]+);", line)
+                    name_match = re.match(r"CFBundle(?:Display|Localized)?Name\s*=\s*([^;]+);", line)
                     if name_match:
                         display_name = name_match.group(1).strip()
                         if display_name == app_name:

--- a/minitap/mobile_use/clients/idb_client.py
+++ b/minitap/mobile_use/clients/idb_client.py
@@ -385,10 +385,7 @@ class IdbClientWrapper:
                     current_bundle_id = bundle_match.group(1)
                     continue
 
-                # Match display name: CFBundleDisplayName, CFBundleLocalizedName,
-                # or CFBundleName — include localized variant so non-English
-                # simulator locales (where AXLabel returns the localized name)
-                # still resolve to the correct bundle ID.
+                # Match display name keys including localized variants so non-English simulator locales resolve to the correct bundle ID.
                 if current_bundle_id:
                     name_match = re.match(r"CFBundle(?:Display|Localized)?Name\s*=\s*([^;]+);", line)
                     if name_match:


### PR DESCRIPTION
﻿## Summary

`app_current()` in `minitap/mobile_use/clients/idb_client.py` resolves the
foreground app bundle ID by fetching the accessible app name via
`idb ui describe-all` (which returns `AXLabel`) and then matching it
against names parsed from `xcrun simctl listapps`.

On non-English simulator locales `AXLabel` returns the **localised** display
name (e.g. `"Réglages"` for Settings in French), but the parser only
matched `CFBundleDisplayName` and `CFBundleName`, which are always the
English names supplied by the developer.  The lookup therefore failed and
`bundle_id` was always returned as `None` when the device language was not
English.

**Fix:** extend the name-matching regex from

```python
r"CFBundle(?:Display)?Name\s*=\s*([^;]+);"
# matches: CFBundleDisplayName, CFBundleName
```

to

```python
r"CFBundle(?:Display|Localized)?Name\s*=\s*([^;]+);"
# matches: CFBundleDisplayName, CFBundleLocalizedName, CFBundleName
```

`CFBundleLocalizedName` is the field that `simctl listapps` populates with
the locale-aware display name, so it is exactly the value that matches what
`AXLabel` reports on a non-English device.

Fixes #151


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app detection to recognize localized application names (including additional localized display name variants) when mapping the currently focused UI element to an app, resolving mismatches on simulators set to different languages.
  * Ensures consistent identification of the active app across device language settings, reducing false negatives when determining which app is in focus.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->