### PR TITLE
Fix: wrap long lines in idb_client.py to pass ruff format check

### DIFF
--- a/minitap/mobile_use/clients/idb_client.py
+++ b/minitap/mobile_use/clients/idb_client.py
@@ -385,9 +385,12 @@ class IdbClientWrapper:
                     current_bundle_id = bundle_match.group(1)
                     continue
 
-                # Match display name keys including localized variants so non-English simulator locales resolve to the correct bundle ID.
+                # Match display name keys including localized variants so
+                # non-English simulator locales resolve to the correct bundle ID.
                 if current_bundle_id:
-                    name_match = re.match(r"CFBundle(?:Display|Localized)?Name\s*=\s*([^;]+);", line)
+                    name_match = re.match(
+                        r"CFBundle(?:Display|Localized)?Name\s*=\s*([^;]+);", line
+                    )
                     if name_match:
                         display_name = name_match.group(1).strip()
                         if display_name == app_name:


### PR DESCRIPTION
## Problem

The \uff format --check\ step in CI fails (see [run 27133598497](https://github.com/minitap-ai/mobile-use/actions/runs/27133598497)) because two lines in \minitap/mobile_use/clients/idb_client.py\ exceed the project's 100-char limit:

1. The comment on line 388 (137 chars) — condensed from multi-line to a single line in commit 887fcec.
2. The \e.match(...)\ call on line 390 (101 chars) — pushed over by adding \|Localized\ in commit 9319672.

## Fix

- Wrapped the long comment onto two lines.
- Ran \uff format\ to auto-wrap the \e.match\ call.

Both \uff format --check\ and \uff check\ now pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code clarity and maintainability with minor formatting adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->