### PR TITLE
fix: wrap long lines in idb_client.py to pass ruff format check

### DIFF
--- a/minitap/mobile_use/clients/idb_client.py
+++ b/minitap/mobile_use/clients/idb_client.py
@@ -385,9 +385,13 @@ class IdbClientWrapper:
                     current_bundle_id = bundle_match.group(1)
                     continue
 
-                # Match display name keys including localized variants so non-English simulator locales resolve to the correct bundle ID.
+                # Match display name keys including localized variants so non-English
+                # simulator locales resolve to the correct bundle ID.
                 if current_bundle_id:
-                    name_match = re.match(r"CFBundle(?:Display|Localized)?Name\s*=\s*([^;]+);", line)
+                    name_match = re.match(
+                        r"CFBundle(?:Display|Localized)?Name\s*=\s*([^;]+);",
+                        line,
+                    )
                     if name_match:
                         display_name = name_match.group(1).strip()
                         if display_name == app_name:


### PR DESCRIPTION
## Summary

Two lines in `minitap/mobile_use/clients/idb_client.py` exceed the 100-character line length limit enforced by `ruff format --check`:

- **Line 388** — a 137-char comment condensed from a multi-line comment in commit 887fcec
- **Line 390** — a 101-char `re.match(...)` call pushed over the limit when `|Localized` was added to the regex in commit 9319672

This PR fixes both by:
- Splitting the long comment across two lines
- Wrapping the `re.match` call with standard ruff-style argument-per-line formatting

Fixes #204

## Changes

- `minitap/mobile_use/clients/idb_client.py`: wrap comment at line 388 and break `re.match` call at line 390 to stay under 100 chars

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code formatting and readability in app matching logic for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->