### PR TITLE
fix(llm-config): remove empty fallback blocks from override template

### DIFF
--- a/llm-config.override.template.jsonc
+++ b/llm-config.override.template.jsonc
@@ -4,7 +4,11 @@
 // You can use any model as long as it is supported by the provider.
 // MiniMax models: MiniMax-M2.7 (200k context), MiniMax-M2.7-highspeed
 
-// Do not modify this file directly, instead copy it to llm.override.jsonc and modify it there.
+// Do not modify this file directly, instead copy it to llm-config.override.jsonc and modify it there.
+
+// Any node may optionally define a "fallback" with a non-empty provider + model
+// (see the commented example on "cortex" below). Leave it out if you don't need one
+// an empty fallback like { "provider": "", "model": "" } is invalid and will be rejected.
 {
   "planner": {
     "provider": "",
@@ -16,11 +20,12 @@
   },
   "cortex": {
     "provider": "",
-    "model": "",
-    "fallback": {
-      "provider": "",
-      "model": ""
-    }
+    "model": ""
+    // Optional fallback, used if the primary call fails:
+    // "fallback": {
+    //   "provider": "openai",
+    //   "model": "gpt-5-mini"
+    // }
   },
   "executor": {
     "provider": "",
@@ -42,11 +47,7 @@
     },
     "video_analyzer": {
       "provider": "",
-      "model": "",
-      "fallback": {
-        "provider": "",
-        "model": ""
-      }
+      "model": ""
     }
   }
 }


### PR DESCRIPTION
## Problem

A user on Discord configured a local LLM via `llm-config.override.jsonc` but mobile-use kept loading the default models (`gpt-5-nano`/`gpt-5`).

Root cause: `parse_llm_config()` deep-merges the override then validates it. If validation throws, it catches the error and **silently discards the entire override**, falling back to defaults:

```python
except ValidationError as e:
    logger.error(f"Invalid llm config: {e}. Falling back to default config")
    return get_default_llm_config()
```

The override template ships `cortex` and `video_analyzer` with an empty `fallback` block (`{ "provider": "", "model": "" }`). Copying the template and filling only the top-level provider/model leaves that empty fallback in place — `""` is not a valid provider literal, so the whole override is dropped.

Reproduced against a local Ollama, then confirmed the fix loads the override correctly.

## Changes

- Remove the empty `fallback` blocks from `cortex` and `video_analyzer` in the template
- Document `fallback` as optional, with a valid commented example on `cortex`
- Add a warning that an empty fallback is invalid and will be rejected
- Fix filename typo in the header comment (`llm.override.jsonc` -> `llm-config.override.jsonc`)

## Follow-up (not in this PR)

Consider making `parse_llm_config` fail loudly or merge per-field instead of silently discarding the whole override on a single invalid field.