### PR TITLE
fix(state): use merge_dicts reducer for scratchpad to prevent key loss on concurrent writes

### DIFF
--- a/minitap/mobile_use/graph/state.py
+++ b/minitap/mobile_use/graph/state.py
@@ -17,6 +17,11 @@ def take_last(a, b):
     return b
 
 
+def merge_dicts(a, b):
+    """Merge two dicts; keys in b overwrite keys in a."""
+    return {**a, **b}
+
+
 class State(BaseModel):
     messages: Annotated[list[AnyMessage], "Sequential messages", add_messages]
     remaining_steps: Annotated[int | None, "Remaining steps before the task is completed"] = None
@@ -62,7 +67,7 @@ class State(BaseModel):
     scratchpad: Annotated[
         dict[str, str],
         "Persistent key-value storage for notes the agent can save and retrieve",
-        take_last,
+        merge_dicts,
     ] = {}
 
     async def asanitize_update(


### PR DESCRIPTION
## Summary

When the executor calls `save_note` multiple times in the same
`executor_tools` superstep (i.e. the LLM emits several tool calls at
once), every `save_note` invocation reads the **same** base
`state.scratchpad` and produces a complete merged-copy update:

```python
updated_scratchpad = {**state.scratchpad, key: content}
```

The previous `take_last` reducer then keeps only the **last** update,
silently discarding all keys written by earlier calls in the same
batch.  With `merge_dicts` as the reducer, LangGraph accumulates each
branch's output via `{**a, **b}`, so every key written by every tool
call in the same superstep survives.

Fixes #208

## Changes

- `minitap/mobile_use/graph/state.py`: add `merge_dicts` helper and use
  it as the reducer for `scratchpad` instead of `take_last`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated how saved app state is combined so new values can be merged into existing stored data instead of replacing it entirely.
  * Improved persistence for the scratchpad, helping preserve previously stored entries while applying updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->