### PR TITLE
fix: trim all overflow messages in a single summarizer pass

### DIFF
--- a/minitap/mobile_use/agents/summarizer/summarizer.py
+++ b/minitap/mobile_use/agents/summarizer/summarizer.py
@@ -27,9 +27,10 @@ class SummarizerNode:
                 start_removal = True
             if start_removal and msg.id:
                 remove_messages.append(RemoveMessage(id=msg.id))
-            return await state.asanitize_update(
-                ctx=self.ctx,
-                update={
-                    "messages": remove_messages,
-                },
-            )
+
+        return await state.asanitize_update(
+            ctx=self.ctx,
+            update={
+                "messages": remove_messages,
+            },
+        )


### PR DESCRIPTION
## Summary

The `return await state.asanitize_update(...)` was indented inside the `for` loop that scans overflow candidates, so the node returned after the very first iteration and removed at most one message per pass — even when history was several messages over `MAX_MESSAGES_IN_HISTORY`.

Moving the `return` outside the loop lets the loop collect every overflow candidate before the state update is emitted, so the history is trimmed back to the configured cap in a single pass.

Fixes #210

## Changes

- `minitap/mobile_use/agents/summarizer/summarizer.py`: dedent `return await state.asanitize_update(...)` to sit outside the `for` loop