### PR TITLE
fix(executor): pass config to _extract_state for langgraph-prebuilt >= 1.1.0

### DIFF
--- a/minitap/mobile_use/agents/executor/tool_node.py
+++ b/minitap/mobile_use/agents/executor/tool_node.py
@@ -54,7 +54,7 @@ class ExecutorToolNode(ToolNode):
         config: RunnableConfig,
         runtime: Runtime,
     ) -> Any:
-        state = self._extract_state(input)
+        state = self._extract_state(input, config)
         return ToolRuntime(
             state=state,
             tool_call_id=call["id"],

--- a/tests/mobile_use/test_executor_tool_node.py
+++ b/tests/mobile_use/test_executor_tool_node.py
@@ -1,0 +1,41 @@
+"""Tests for ExecutorToolNode (regression for issue #213)."""
+
+from unittest.mock import Mock
+
+from langchain_core.tools import tool
+
+from minitap.mobile_use.agents.executor.tool_node import ExecutorToolNode
+
+
+@tool
+def dummy_tool() -> str:
+    """A no-op tool used only for constructing the node."""
+    return "ok"
+
+
+def _make_runtime() -> Mock:
+    runtime = Mock()
+    runtime.context = None
+    runtime.store = None
+    runtime.stream_writer = None
+    return runtime
+
+
+def test_build_tool_runtime_forwards_config():
+    """_extract_state requires `config` on langgraph-prebuilt >= 1.1.0.
+
+    Regression test for #213: _build_tool_runtime called
+    `self._extract_state(input)` without the `config` argument, raising
+    `TypeError: ToolNode._extract_state() missing 1 required positional
+    argument: 'config'` on every tool execution.
+    """
+    node = ExecutorToolNode(tools=[dummy_tool], messages_key="messages")
+    call = {"name": "dummy_tool", "args": {}, "id": "call_1", "type": "tool_call"}
+    input_state = {"messages": []}
+    config = {"configurable": {"thread_id": "test-thread"}}
+
+    tool_runtime = node._build_tool_runtime(call, input_state, config, _make_runtime())
+
+    assert tool_runtime.config == config
+    assert tool_runtime.state == input_state
+    assert tool_runtime.tool_call_id == "call_1"


### PR DESCRIPTION
Fixes #213.

## Problem

`langgraph-prebuilt` 1.1.0 changed `ToolNode._extract_state` to require a `config` parameter:

```python
def _extract_state(
    self,
    input: list[AnyMessage] | dict[str, Any] | BaseModel,
    config: RunnableConfig,
) -> ...
```

`ExecutorToolNode._build_tool_runtime` still calls `self._extract_state(input)`, so once the floating `langgraph>=1.0.2,<2.0.0` pin resolves to 1.1.x, **every tool execution** raises:

```
TypeError: ToolNode._extract_state() missing 1 required positional argument: 'config'
```

## Fix

Forward the `config` that is already a parameter of `_build_tool_runtime`:

```python
state = self._extract_state(input, config)
```

## Tests

Added `tests/mobile_use/test_executor_tool_node.py` — an offline regression test that drives `_build_tool_runtime` directly:

- **fails on the old call** with the exact reported `TypeError` (verified against langgraph-prebuilt 1.1.0)
- **passes with the fix**, asserting the resulting `ToolRuntime` carries the extracted state, the `config`, and the tool call id

Verified locally: `pytest tests/mobile_use/test_executor_tool_node.py` → 1 passed; `ruff format --check` and `ruff check` clean on both files.