### PR TITLE
docs(readme): fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,8 +275,8 @@ We love contributions! Whether you're fixing a bug, adding a feature, or improvi
 ## ⭐ Star History
 
 <p align="center">
-  <a href="https://star-history.com/#minitap-ai/mobile-use&Date">
-    <img src="https://api.star-history.com/svg?repos=minitap-ai/mobile-use&type=Date" alt="Star History Chart" />
+  <a href="https://star-history.dera.page/#minitap-ai/mobile-use&Date">
+    <img src="https://star-history.dera.page/svg?repos=minitap-ai/mobile-use&type=Date" alt="Star History Chart" />
   </a>
 </p>
 


### PR DESCRIPTION
The star history chart in the README is currently broken because it depends on the GitHub stargazer API, which is now restricted. This change points the chart to the dera.page mirror, which uses a different data source that requires no API token, so the star history chart works again.