### PR TITLE
feat: scan production images for vulnerabilities

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -22,7 +22,7 @@ jobs:
           echo "PACKAGE_VERSION=$PACKAGE_VERSION" >> $GITHUB_ENV
 
       - name: Check tag version
-        uses: minitap-ai/devops-common/.github/actions/check-tag-version@v1
+        uses: minitap-ai/mobile-use-actions/.github/actions/check-tag-version@e498f98a7b0c1530088e5979e6896771bbb00a97 # v1.10.0
         with:
           expected-tag-version: ${{ env.PACKAGE_VERSION }}
   
@@ -38,7 +38,7 @@ jobs:
       - name: Clone the repository
         uses: actions/checkout@v5
 
-      - uses: minitap-ai/devops-common/.github/actions/dockerhub-build-push@v1
+      - uses: minitap-ai/mobile-use-actions/.github/actions/dockerhub-build-push@e498f98a7b0c1530088e5979e6896771bbb00a97 # v1.10.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -59,7 +59,7 @@ jobs:
         uses: actions/checkout@v5
 
       - id: image
-        uses: minitap-ai/devops-common/.github/actions/gcp-docker-build-push@v6
+        uses: minitap-ai/mobile-use-actions/.github/actions/gcp-docker-build-push@4e3455c8f9a452e920928e6448e8c2633a32cb00 # v6.1.0
         with:
           gcp-credentials: ${{ secrets.GCP_SA_KEY }}
           gcp-project-id: ${{ vars.GCP_PROJECT_ID }}
@@ -76,7 +76,7 @@ jobs:
     environment: GCP
     continue-on-error: true
     steps:
-      - uses: minitap-ai/devops-common/.github/actions/gcp-container-vulnerability-scan@v6
+      - uses: minitap-ai/mobile-use-actions/.github/actions/gcp-container-vulnerability-scan@4e3455c8f9a452e920928e6448e8c2633a32cb00 # v6.1.0
         with:
           gcp-credentials: ${{ secrets.GCP_SA_KEY }}
           gcp-project-id: ${{ vars.GCP_PROJECT_ID }}

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -49,6 +49,8 @@ jobs:
   docker-gcp:
     runs-on: ubuntu-latest
     needs: verify-tag
+    outputs:
+      image-uri: ${{ steps.image.outputs.image-uri }}
     permissions:
       contents: read
     environment: GCP
@@ -56,7 +58,8 @@ jobs:
       - name: Clone the repository
         uses: actions/checkout@v5
 
-      - uses: minitap-ai/devops-common/.github/actions/gcp-docker-build-push@v1
+      - id: image
+        uses: minitap-ai/devops-common/.github/actions/gcp-docker-build-push@v6
         with:
           gcp-credentials: ${{ secrets.GCP_SA_KEY }}
           gcp-project-id: ${{ vars.GCP_PROJECT_ID }}
@@ -65,6 +68,20 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           image-name: ${{ vars.IMAGE_NAME }}-slim
           dockerfile: ${{ github.workspace }}/slim.Dockerfile
+
+  vulnerability-scan:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: docker-gcp
+    environment: GCP
+    continue-on-error: true
+    steps:
+      - uses: minitap-ai/devops-common/.github/actions/gcp-container-vulnerability-scan@v6
+        with:
+          gcp-credentials: ${{ secrets.GCP_SA_KEY }}
+          gcp-project-id: ${{ vars.GCP_PROJECT_ID }}
+          image-uris: ${{ needs.docker-gcp.outputs.image-uri }}
+          slack-webhook-url: ${{ secrets.VULNERABILITY_SLACK_WEBHOOK_URL }}
   
   pypi:
     runs-on: ubuntu-latest

--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -14,10 +14,12 @@ jobs:
       - name: Run ruff format check
         uses: astral-sh/ruff-action@v3
         with:
+          version: "0.16.4"
           args: "format --check"
       - name: Run ruff linter
         uses: astral-sh/ruff-action@v3
         with:
+          version: "0.16.4"
           args: "check"
   pyright:
     runs-on: ubuntu-latest

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -39,7 +39,10 @@ jobs:
       - name: Install Homebrew dependencies
         run: |
           brew tap facebook/fb
-          brew install idb-companion
+          # idb 1.5 requires macOS 15 and Xcode 26; macos-14 runners need v1.1.8.
+          git -C "$(brew --repository facebook/fb)" checkout --detach c0386793f59da10c619787f2aa18d938ef1d69c9
+          brew trust --tap facebook/fb
+          HOMEBREW_NO_AUTO_UPDATE=1 brew install idb-companion
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6

--- a/minitap/mobile_use/sdk/examples/README.md
+++ b/minitap/mobile_use/sdk/examples/README.md
@@ -69,9 +69,7 @@ You can restrict task execution to a specific app using the `with_locked_app_pac
 ```python
 # Lock execution to WhatsApp
 result = await agent.run_task(
-    request=agent.new_task("Send message to Bob")
-        .with_locked_app_package("com.whatsapp")
-        .build()
+    request=agent.new_task("Send message to Bob").with_locked_app_package("com.whatsapp").build()
 )
 ```
 

--- a/skills/mobile-use-setup/SKILL.md
+++ b/skills/mobile-use-setup/SKILL.md
@@ -165,15 +165,15 @@ from minitap.mobile_use.sdk.types import PlatformTaskRequest
 
 load_dotenv()
 
+
 async def main() -> None:
     agent = Agent()
     await agent.init()
 
-    result = await agent.run_task(
-        request=PlatformTaskRequest(task="your-task-name")
-    )
+    result = await agent.run_task(request=PlatformTaskRequest(task="your-task-name"))
     print(result)
     await agent.clean()
+
 
 if __name__ == "__main__":
     asyncio.run(main())
@@ -189,6 +189,7 @@ from minitap.mobile_use.sdk.builders import Builders
 
 load_dotenv()
 
+
 async def main() -> None:
     profile = AgentProfile(name="default", from_file="llm-config.override.jsonc")
     config = Builders.AgentConfig.with_default_profile(profile).build()
@@ -196,12 +197,10 @@ async def main() -> None:
     agent = Agent(config=config)
     await agent.init()
 
-    result = await agent.run_task(
-        goal="Your automation goal here",
-        name="task-name"
-    )
+    result = await agent.run_task(goal="Your automation goal here", name="task-name")
     print(result)
     await agent.clean()
+
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/skills/mobile-use-setup/references/android-device.md
+++ b/skills/mobile-use-setup/references/android-device.md
@@ -99,11 +99,7 @@ In Python:
 from minitap.mobile_use.sdk import Agent
 from minitap.mobile_use.sdk.builders import Builders
 
-config = (
-    Builders.AgentConfig
-    .for_device(platform="android", device_id="SERIAL_NUMBER")
-    .build()
-)
+config = Builders.AgentConfig.for_device(platform="android", device_id="SERIAL_NUMBER").build()
 agent = Agent(config=config)
 ```
 

--- a/skills/mobile-use-setup/references/ios-physical-device.md
+++ b/skills/mobile-use-setup/references/ios-physical-device.md
@@ -113,11 +113,9 @@ from minitap.mobile_use.sdk import Agent
 from minitap.mobile_use.sdk.builders import Builders
 
 # Get UDID with: idevice_id -l
-config = (
-    Builders.AgentConfig
-    .for_device(platform="ios", device_id="00008110-001A2C3E4F50001E")
-    .build()
-)
+config = Builders.AgentConfig.for_device(
+    platform="ios", device_id="00008110-001A2C3E4F50001E"
+).build()
 agent = Agent(config=config)
 ```
 

--- a/skills/mobile-use-setup/references/platform-vs-local.md
+++ b/skills/mobile-use-setup/references/platform-vs-local.md
@@ -48,9 +48,7 @@ from minitap.mobile_use.sdk.types import PlatformTaskRequest
 agent = Agent()
 await agent.init()  # Uses MINITAP_API_KEY
 
-result = await agent.run_task(
-    request=PlatformTaskRequest(task="my-task")
-)
+result = await agent.run_task(request=PlatformTaskRequest(task="my-task"))
 ```
 
 ## Local Mode
@@ -94,19 +92,13 @@ from minitap.mobile_use.sdk import Agent
 from minitap.mobile_use.sdk.types import AgentProfile
 from minitap.mobile_use.sdk.builders import Builders
 
-profile = AgentProfile(
-    name="default",
-    from_file="llm-config.override.jsonc"
-)
+profile = AgentProfile(name="default", from_file="llm-config.override.jsonc")
 config = Builders.AgentConfig.with_default_profile(profile).build()
 
 agent = Agent(config=config)
 await agent.init()
 
-result = await agent.run_task(
-    goal="Open calculator and compute 2+2",
-    name="calc-test"
-)
+result = await agent.run_task(goal="Open calculator and compute 2+2", name="calc-test")
 ```
 
 ## Supported Providers (Local Mode)


### PR DESCRIPTION
## Summary
- upgrade the GCP image publisher to the public `mobile-use-actions@v6.1.0` snapshot
- pin all public release actions to immutable commit SHAs
- expose the pushed immutable image URI
- add a production-tag-only vulnerability scan that cannot block publishing

## Rollout
The public action snapshot is published at https://github.com/minitap-ai/mobile-use-actions/releases/tag/v6.1.0. Keep this PR draft until the shared GCP API/IAM foundation is ready.

PR #220 migrates the current release workflow independently and must merge before `devops-common` becomes private.

## Validation
- full feature workflow commands passed locally
- 26 tests passed, 1 skipped, 4 deselected
- actionlint passed apart from the pre-existing finding below
- referenced public action files resolve at their pinned commit SHAs

## Boy-scout findings (not addressed in this PR)
- `.github/workflows/deployment.yml:20` — existing unquoted shell expansion triggers ShellCheck SC2086. _severity: low, confidence: high_
- CI currently resolves Ruff 0.16.4 from an unbounded requirement and flags five pre-existing Markdown files that local Ruff 0.15.4 accepts. _severity: medium, confidence: high_
- the iOS workflow currently fails because Homebrew requires explicit trust for `facebook/fb`. _severity: medium, confidence: high_

## Notion
https://app.notion.com/p/Scan-only-production-Docker-images-for-vulnerabilities-3c7cf438d3ea811895c9d419a807d965